### PR TITLE
add effects and ANOVAtest function for lm

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -15,6 +15,7 @@ module GLM
     import NumericExtensions: evaluate, result_type
 
     export                              # types
+        ANOVAtest,
         CauchitLink,
         CloglogLink,
         DensePred,
@@ -33,6 +34,7 @@ module GLM
         LmResp,
         ProbitLink,
                                         # functions
+        ANOVAtest,      #ANOVA style test fro set of terms in formula or columns of X from LmMod
         canonicallink,  # canonical link function for a distribution
         contr_treatment,# treatment contrasts
         delbeta!,       # evaluate the increment in the coefficient vector
@@ -40,6 +42,7 @@ module GLM
         devresid,       # vector of squared deviance residuals
         df_residual,    # degrees of freedom for residuals
         drsum,          # sum of squared deviance residuals
+        effects,        # effects for terms in formula or columns of X in LmMod
         fit,            # function to fit models, from StatsBase
         formula,        # extract the formula from a model
         glm,            # general interface

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -63,3 +63,102 @@ function confint(obj::LmMod, level::Real)
     quantile(TDist(df_residual(obj)), (1. - level)/2.) * [1. -1.]
 end
 confint(obj::LmMod) = confint(obj, 0.95)
+
+effects(mod::RegressionModel)=(mod.model.pp.qr[:Q]'*mod.model.rr.y)[1:size(mod.model.pp.X,2)]
+effects(mod::LmMod{DensePredQR{Float64}})=(mod.pp.qr[:Q]'*mod.rr.y)[1:size(mod.pp.X,2)]
+
+type ANOVAtest
+    SSH::Float64
+    SSE::Float64
+    MSH::Float64
+    MSE::Float64
+    dfH::Int
+    dfE::Int
+    fstat::Float64
+    pval::Float64    #regular pvalue or -log10pval
+    log10pval::Bool
+end
+
+#this is a test for a group of terms from a LmMod derived from a formula and dataframe
+function ANOVAtest(mod::RegressionModel,terms::Array{Int,1}; log10pval=false)
+    #terms is arrary of number for each term in the model to be tested together, starting with the intercept at 0
+    eff=effects(mod)  #get effect for each coefficient
+    ind=findin(mod.mm.assign,terms)
+    eff=eff[ind]
+    SSH=sum(Abs2Fun(),eff)
+    dfH=length(eff)
+    MSH=SSH/dfH
+    SSE=deviance(mod.model.rr)
+    dfE=df_residual(mod.model.pp)
+    MSE=SSE/dfE
+    fstat=MSH/MSE
+    pval=ccdf(FDist(dfH, dfE), fstat)
+    if log10pval pval= -log10(pval) end
+    return ANOVAtest(SSH,SSE,MSH,MSE,dfH,dfE,fstat,pval,log10pval)
+end
+
+#this is a test for a single term from a LmMod derived from a formula and dataframe
+function ANOVAtest(mod::RegressionModel,term::Int; log10pval=false)
+    #term an integer for a single term in model to be tested, starting with the intercept at 0
+    eff=effects(mod)  #get effect for each coefficient
+    ind=findin(mod.mm.assign,term)
+    eff=eff[ind]
+    SSH=eff[1]*eff[1]
+    dfH=length(eff)
+    MSH=SSH/dfH
+    SSE=deviance(mod.model.rr)
+    dfE=df_residual(mod.model.pp)
+    MSE=SSE/dfE
+    fstat=MSH/MSE
+    pval=ccdf(FDist(dfH, dfE), fstat)
+    if log10pval pval= -log10(pval) end
+    return ANOVAtest(SSH,SSE,MSH,MSE,dfH,dfE,fstat,pval,log10pval)
+end
+
+
+#this is a test for a group of coefficients/columns of X based on a LmMod derived without a formula and dataframe
+function ANOVAtest(mod::LmMod{DensePredQR{Float64}},cols::Array{Int,1}; log10pval=false)
+    #cols a vector of position numbers (column number of X) to be grouped together with the intercept starting at 1
+    #this does not refer the terms of a model defined by a formula if a term has >1 DF
+    eff=effects(mod)  #get effect for each coefficient
+    eff=eff[cols]
+    SSH=sum(Abs2Fun(),eff)
+    dfH=length(eff)
+    MSH=SSH/dfH
+    SSE=deviance(mod.rr)
+    dfE=df_residual(mod.pp)
+    MSE=SSE/dfE
+    fstat=MSH/MSE
+    pval=ccdf(FDist(dfH, dfE), fstat)
+    if log10pval pval= -log10(pval) end
+    return ANOVAtest(SSH,SSE,MSH,MSE,dfH,dfE,fstat,pval,log10pval)
+end
+
+#this is a test for a single coefficient/columns of X based on a LmMod derived without a formula and dataframe
+function ANOVAtest(mod::LmMod{DensePredQR{Float64}},col::Int; log10pval=false)
+    #col means the position number of the column of X with the intercept starting at 1
+    #this does not refer the terms of a model defined by a formula if a term has >1 DF
+    eff=effects(mod)  #get effect for each coefficient
+    eff=eff[col]
+    SSH=eff[1]*eff[1]
+    dfH=length(eff)
+    MSH=SSH/dfH
+    SSE=deviance(mod.rr)
+    dfE=df_residual(mod.pp)
+    MSE=SSE/dfE
+    fstat=MSH/MSE
+    pval=ccdf(FDist(dfH, dfE), fstat)
+    if log10pval pval= -log10(pval) end
+    return ANOVAtest(SSH,SSE,MSH,MSE,dfH,dfE,fstat,pval,log10pval)
+end
+
+function Base.show(io::IO,at::ANOVAtest)
+    if at.log10pval
+        println("              ","DF",'\t',"SS",'\t',"MS",'\t',"F",'\t',"log10pval")
+    else
+        println("              ","DF",'\t',"SS",'\t',"MS",'\t',"F",'\t',"pval")
+    end
+    println("Hypothesis    ",round(at.dfH,3),'\t',round(at.SSH,3),'\t',round(at.MSH,3),'\t',round(at.fstat,3),'\t',at.pval)
+    println("Residuals     ",round(at.dfE,3),'\t', round(at.SSE,3),'\t', round(at.MSE,3))
+end
+


### PR DESCRIPTION
Instead of an ANOVA table that was previously discussed and there were issues about it's potential misuse and abuse.  This is a specific, full vs reduced model test where the effects from the desired terms are grouped together in a hypothesis to form a ANOVA style F test.

The effects function extracts the effects from an LmMod either produced with a formula and dataframe or from LmMod produced using a y and X matrix.  ANOVA test allows you to specify terms in an LmMod model to do an anova (full vs reduced) test.  You can specify 1 or more terms if the model was produced with a formula and data frame.  If the LmMod was produced with a y and X, you can specify the columns of X that you would like to group together.  ANOVAtest is a type to hold DF,SS,MS,F, and either the pval or -log10pval.  It has a show function that produces a table.

Note, that if the model is produced from a formula and dataframe the terms can be specified by their position in the formula where the intercept is 0.  A single term can have multiple degrees of freedom if it involves factors.  If the model is produced from specified y and X then the user will need to specify what columns of the X matrix would need to be tested (i.e. we do not know the terms from the model if factors are involved.

The names, the option for log10pval, and how I did the show function are just what I put together and have no attachment to.  I was also not certain how to deal with the term number and column number difference between models derived with and without formula's and data frames.

Below are some simple examples.
a=randn(100,4);
b=convert(DataFrame,a);

c=fit(LmMod,x1~x2+x3+x4,b)   #fit model with formula and dataframe
d=ANOVAtest(c,[2,3],log10pval=true)  #test of multiple terms in the formula with LmMod made with formula and dataframe
e=ANOVAtest(c,3)     #test of a single term of X with LmMod made with formula and dataframe
f=ANOVAtest(c,[3])    #shows that you can also do one term with a single cell array

g=fit(LmMod,c.model.pp.X,c.model.rr.y)   #fit model with X and y without formula or dataframe
h=ANOVAtest(g,[3,4])  #test of multiple columns of X with LmMod made without formula and dataframe
i=ANOVAtest(g,4)   #test of a single column of X with LmMod made without formula and dataframe
j=ANOVAtest(g,[4])    #shows that you can also do one term was a single cell array
