### PR TITLE
change symbol to char for call to Cholesky

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -37,10 +37,10 @@ end
 DensePredChol{T<:BlasReal}(X::Matrix{T}) = DensePredChol{T}(X, zeros(T,size(X,2)))
 
 if VERSION >= v"0.4.0-dev+122"
-    cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky{T,Matrix{T},:U}(p.qr[:R])
+    cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky{T,Matrix{T},'U'}(p.qr[:R])
     cholfact{T<:FP}(p::DensePredChol{T}) = (c = p.chol; typeof(c)(copy(c.UL)))
 else
-    cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky(p.qr[:R], :U)
+    cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky(p.qr[:R], 'U')
     cholfact{T<:FP}(p::DensePredChol{T}) = (c = p.chol; Cholesky(copy(c.UL),c.uplo))
 end
 


### PR DESCRIPTION
I got an error when trying to run a lm model.  It actually makes the model but fails in show because it failed in Stderr in the Coeftable which called the vcov function which called cholfact with a DensePredQR argument which called Cholesky.  The second argument to Cholesky in Base.LinAlg.Cholesky should be a Char instead of a symbol:

methods(Base.LinAlg.Cholesky)
Cholesky{T}(UL::Array{T,2},uplo::Char)

After the change it appears to work fine.
