### PR TITLE
Remove NumericExtensions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.3-
 Distributions 0.4.6-
-NumericExtensions 0.6-
 NumericFuns 0.2.1-
 StatsBase 0.3.9+
+Reexport
+Compat 0.2.12-

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,18 +1,18 @@
-using GLM
-glm(y ~ 1, DataFrame(y = float64(randbool(10))), Binomial())
+using GLM, DataFrames
+glm(y ~ 1, DataFrame(y = float64(bitrand(10))), Binomial())
 
 n = 2_500_000; srand(1234321)
 df2 = DataFrame(x1 = rand(Normal(), n),
                 x2 = rand(Exponential(), n),
                 ss = pool(rand(DiscreteUniform(50), n)));
+mf = ModelFrame(x1 ~ x1 + x2 + ss, df2)
+mm = ModelMatrix(mf)
 beta = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 
 ## Create linear predictor and mean response
-df2["eta"] = eta = ModelMatrix(ModelFrame(x1 ~ x1 + x2 + ss, df2)).m * beta;
-df2["mu"] = mu = linkinv!(LogitLink(), similar(eta), eta); 
+eta = mm.m * beta;
+mu = linkinv!(LogitLink(), similar(eta), eta); 
+y = float64(rand(n) .< mu);        # simulate observed responses
 
-df2["y"] = float64(rand(n) .< mu);        # simulate observed responses
-head(df2)
-
-gm6 = glm(y ~ x1 + x2 + ss, df2, Binomial())
-@time glm(y ~ x1 + x2 + ss, df2, Binomial());
+gm6 = glm(mm.m, y, Binomial())
+@time glm(mm.m, y, Binomial());

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -16,3 +16,4 @@ y = float64(rand(n) .< mu);        # simulate observed responses
 
 gm6 = glm(mm.m, y, Binomial())
 @time glm(mm.m, y, Binomial());
+# Profile.print()

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -1,8 +1,6 @@
-using Distributions, NumericExtensions
-
 module GLM
-
-    using Distributions, NumericExtensions, NumericFuns
+    using NumericFuns, Reexport, Compat
+    @reexport using Distributions
     using Base.LinAlg.LAPACK: potrf!, potrs!
     using Base.LinAlg.BLAS: gemm!, gemv!
     using Base.LinAlg: QRCompactWY, Cholesky
@@ -12,7 +10,7 @@ module GLM
     import Base: (\), cholfact, cor, scale, show, size
     import StatsBase: coef, coeftable, confint, deviance, loglikelihood, nobs, stderr,
                       vcov, residuals, predict, fit
-    import NumericExtensions: evaluate, result_type
+    import NumericFuns: evaluate
 
     export                              # types
         CauchitLink,

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -75,10 +75,11 @@ type BinomialMuStart <: Functor{2} end
 evaluate{T<:FP}(::BinomialMuStart,y::T,w::T) = (w*y + convert(T,0.5))/(w + one(T))
 result_type{T<:FP}(::BinomialMuStart,::Type{T},::Type{T}) = T
 
-mustart{T<:FP}(::Binomial,y::Vector{T},wt::Vector{T}) = map(BinomialMuStart(),y,wt)
-mustart{T<:FP}(::Gamma,y::Vector{T},::Vector{T}) = copy(y)
-mustart{T<:FP}(::Normal,y::Vector{T},::Vector{T}) = copy(y)
-mustart{T<:FP}(::Poisson,y::Vector{T},::Vector{T}) = y .+ convert(T,0.1)
+mustart!{T<:FP}(::Binomial,mu::Vector{T},y::Vector{T},wt::Vector{T}) = map!(BinomialMuStart(),mu,y,wt)
+mustart!{T<:FP}(::Gamma,mu::Vector{T},y::Vector{T},::Vector{T}) = copy!(mu, y)
+mustart!{T<:FP}(::Normal,mu::Vector{T},y::Vector{T},::Vector{T}) = copy!(mu, y)
+mustart!{T<:FP}(::Poisson,mu::Vector{T},y::Vector{T},::Vector{T}) = broadcast!(+, mu, y, convert(T,0.1))
+mustart{T<:FP}(d::Distribution,y::Vector{T},wt::Vector{T}) = mustart!(d, similar(y), y, wt)
 
 for Op in [:BernoulliVar,
            :CauchLink, :CauchInv, :CauchME,

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -1,3 +1,28 @@
+using Base.Cartesian
+
+@ngenerate N typeof(A) function simdmap!(f, A::AbstractArray, Xs::NTuple{N,AbstractArray}...)
+    @nexprs N d->(length(Xs_d) == length(A) || throw(DimensionMismatch()))
+    @inbounds @simd for i = 1:length(A)
+        @nexprs N k->(v_k = Xs_k[i])
+        A[i] = @ncall N evaluate f v
+    end
+    A
+end
+# stagedfunction simdmap!(f, A::AbstractArray, Xs::AbstractArray...)
+#     lengthcheck = Expr(:comparison, :(length(A)))
+#     for i = 1:length(Xs)
+#         push!(lengthcheck.args, :(==))
+#         push!(lengthcheck.args, :(length(Xs[$i])))
+#     end
+#     quote
+#         $lengthcheck || throw(DimensionMismatch())
+#         @inbounds @simd for i = 1:length(A)
+#             A[i] = $(Expr(:call, :evaluate, :f, [:(Xs[$j][i]) for j = 1:length(Xs)]...))
+#         end
+#         A
+#     end
+# end
+
 abstract Link             # Link types define linkfun!, linkinv!, and mueta!
 
 type CauchitLink <: Link end
@@ -38,7 +63,7 @@ type LogisticFun <: Functor{1} end
 evaluate{T<:FP}(::LogisticFun,x::T) = one(x) / (one(x) + exp(-x))
 
 
-                                        # IdentityLink is a special case - nothing to map
+# IdentityLink is a special case - nothing to map
 linkfun!{T<:FP}(::IdentityLink, eta::Vector{T}, mu::Vector{T}) = copy!(eta,mu)
 linkinv!{T<:FP}(::IdentityLink, mu::Vector{T}, eta::Vector{T}) = copy!(mu,eta)
 mueta!{T<:FP}(::IdentityLink, me::Vector{T}, eta::Vector{T}) = fill!(me,one(T))
@@ -52,9 +77,9 @@ for (l, lf, li, mueta) in
      (:ProbitLink, :ProbLink, :ProbInv, :ProbME),
      (:SqrtLink, :SqrtFun, :Abs2Fun, :SqrtME))
     @eval begin
-        linkfun!{T<:FP}(::$l,eta::Vector{T},mu::Vector{T}) = map!($lf(),eta,mu)
-        linkinv!{T<:FP}(::$l,mu::Vector{T},eta::Vector{T}) = map!($li(),mu,eta)
-        mueta!{T<:FP}(::$l,me::Vector{T},eta::Vector{T}) = map!($mueta(),me,eta)
+        linkfun!{T<:FP}(::$l,eta::Vector{T},mu::Vector{T}) = simdmap!($lf(),eta,mu)
+        linkinv!{T<:FP}(::$l,mu::Vector{T},eta::Vector{T}) = simdmap!($li(),mu,eta)
+        mueta!{T<:FP}(::$l,me::Vector{T},eta::Vector{T}) = simdmap!($mueta(),me,eta)
     end
 end
 
@@ -66,63 +91,48 @@ canonicallink(::Poisson) = LogLink()
 type BernoulliVar <: Functor{1} end
 evaluate{T<:FP}(::BernoulliVar,x::T) = x * (one(T) - x)
 
-var!{T<:FP}(::Binomial,v::Vector{T},mu::Vector{T}) = map!(BernoulliVar(),v,mu)
-var!{T<:FP}(::Gamma,v::Vector{T},mu::Vector{T}) = map!(Abs2Fun(),v,mu)
+var!{T<:FP}(::Binomial,v::Vector{T},mu::Vector{T}) = simdmap!(BernoulliVar(),v,mu)
+var!{T<:FP}(::Gamma,v::Vector{T},mu::Vector{T}) = simdmap!(Abs2Fun(),v,mu)
 var!{T<:FP}(::Normal,v::Vector{T},mu::Vector{T}) = fill!(v,one(T))
 var!{T<:FP}(::Poisson,v::Vector{T},mu::Vector{T}) = copy!(v,mu)
 
 type BinomialMuStart <: Functor{2} end
 evaluate{T<:FP}(::BinomialMuStart,y::T,w::T) = (w*y + convert(T,0.5))/(w + one(T))
-result_type{T<:FP}(::BinomialMuStart,::Type{T},::Type{T}) = T
 
-mustart!{T<:FP}(::Binomial,mu::Vector{T},y::Vector{T},wt::Vector{T}) = map!(BinomialMuStart(),mu,y,wt)
+mustart!{T<:FP}(::Binomial,mu::Vector{T},y::Vector{T},wt::Vector{T}) = simdmap!(BinomialMuStart(),mu,y,wt)
 mustart!{T<:FP}(::Gamma,mu::Vector{T},y::Vector{T},::Vector{T}) = copy!(mu, y)
 mustart!{T<:FP}(::Normal,mu::Vector{T},y::Vector{T},::Vector{T}) = copy!(mu, y)
 mustart!{T<:FP}(::Poisson,mu::Vector{T},y::Vector{T},::Vector{T}) = broadcast!(+, mu, y, convert(T,0.1))
 mustart{T<:FP}(d::Distribution,y::Vector{T},wt::Vector{T}) = mustart!(d, similar(y), y, wt)
-
-for Op in [:BernoulliVar,
-           :CauchLink, :CauchInv, :CauchME,
-           :CLgLgLink, :CLgLgInv, :CLgLgME,
-           :InvME,
-           :LogitME,
-           :ProbLink, :ProbInv, :ProbME]
-    @eval result_type{T<:FP}(::$(Op), ::Type{T}) = T
-end
-
 
 type BinomialDevResid <: Functor{3} end
 function evaluate{T<:FP}(::BinomialDevResid,y::T,mu::T,wt::T)
     omy = one(T)-y
     2.wt*(xlogy(y,y/mu) + xlogy(omy,omy/(one(T)-mu)))
 end
-result_type{T<:FP}(::BinomialDevResid,::Type{T},::Type{T},::Type{T}) = T
 
 type PoissonDevResid <: Functor{3} end
 evaluate{T<:FP}(::PoissonDevResid,y::T,mu::T,wt::T) = 2.wt * (xlogy(y,y/mu) - (y - mu))
-result_type{T<:FP}(::PoissonDevResid,::Type{T},::Type{T},::Type{T}) = T
 
 type GammaDevResid <: Functor{3} end
 evaluate{T<:FP}(::GammaDevResid,y::T,mu::T,wt::T) = -2.wt * (log(y/mu) - (y - mu)/mu)
-result_type{T<:FP}(::GammaDevResid,::Type{T},::Type{T},::Type{T}) = T
 
 type GaussianDevResid <: Functor{3} end
 evaluate{T<:FP}(::GaussianDevResid,y::T,mu::T,wt::T) = wt * abs2(y - mu)
-result_type{T<:FP}(::GaussianDevResid,::Type{T},::Type{T},::Type{T}) = T
 
 function devresid!{T<:FP}(::Binomial,dr::Vector{T},y::Vector{T},
                                      mu::Vector{T},wt::Vector{T})
-    map!(BinomialDevResid(), dr, y, mu, wt)
+    simdmap!(BinomialDevResid(), dr, y, mu, wt)
 end
 function devresid!{T<:FP}(::Poisson,dr::Vector{T},y::Vector{T},
                                      mu::Vector{T},wt::Vector{T})
-    map!(PoissonDevResid(), dr, y, mu, wt)
+    simdmap!(PoissonDevResid(), dr, y, mu, wt)
 end
 function devresid!{T<:FP}(::Gamma,dr::Vector{T},y::Vector{T},
                                   mu::Vector{T},wt::Vector{T})
-    map!(GammaDevResid(), dr, y, mu, wt)
+    simdmap!(GammaDevResid(), dr, y, mu, wt)
 end
 function devresid!{T<:FP}(::Normal,dr::Vector{T},y::Vector{T},
                                      mu::Vector{T},wt::Vector{T})
-    map!(GaussianDevResid(), dr, y, mu, wt)
+    simdmap!(GaussianDevResid(), dr, y, mu, wt)
 end


### PR DESCRIPTION
Fixes  #94. The performance on the benchmark in `perf` is very slightly faster (~2%).

This also includes some miscellaneous changes from my working copy:
- Improved type stability
- Ability to specify starting coefficients
- Better handling of steps that result in invalid eta values
- Re-export Distributions instead of bringing it into Main