### PR TITLE
Make predict work with offsets

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -232,15 +232,14 @@ function scale(m::GeneralizedLinearModel, sqr::Bool=false)
 end
 
 ## Prediction function for GLMs
-function predict(mm::GeneralizedLinearModel, newX::AbstractMatrix; offset=nothing)
+function predict(mm::GeneralizedLinearModel, newX::AbstractMatrix; offset::FPVector=Array(eltype(newX),0))
     eta = newX * coef(mm)
     if length(mm.rr.offset) > 0
-        isa(offset, FPVector) &&
-            length(offset) == size(newX, 1) ||
+        length(offset) == size(newX, 1) ||
             error(ArgumentError("fit with offset, so `offset` kw arg must be an offset of length `size(newX, 1)`"))
         simdmap!(Add(), eta, eta, offset)
     else
-        isa(offset, FPVector) && length(offset) > 0 && error(ArgumentError("fit without offset, so value of `offset` kw arg does not make sense"))
+        length(offset) > 0 && error(ArgumentError("fit without offset, so value of `offset` kw arg does not make sense"))
     end
     mu = linkinv!(mm.rr.l, eta, eta)
 end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -232,7 +232,15 @@ function scale(m::GeneralizedLinearModel, sqr::Bool=false)
 end
 
 ## Prediction function for GLMs
-function predict(mm::GeneralizedLinearModel, newX::AbstractMatrix)
+function predict(mm::GeneralizedLinearModel, newX::AbstractMatrix; offset=nothing)
     eta = newX * coef(mm)
+    if length(mm.rr.offset) > 0
+        isa(offset, FPVector) &&
+            length(offset) == size(newX, 1) ||
+            error(ArgumentError("fit with offset, so `offset` kw arg must be an offset of length `size(newX, 1)`"))
+        simdmap!(Add(), eta, eta, offset)
+    else
+        isa(offset, FPVector) && length(offset) > 0 && error(ArgumentError("fit without offset, so value of `offset` kw arg does not make sense"))
+    end
     mu = linkinv!(mm.rr.l, eta, eta)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,17 +90,26 @@ Y = logistic(X * [3; -3])
 gm11 = fit(GeneralizedLinearModel, X, Y, Binomial())
 @test_approx_eq predict(gm11) Y
 
-newX = rand(10, 2)
+newX = rand(5, 2)
 newY = logistic(newX * coef(gm11))
 @test_approx_eq predict(gm11, newX) newY
+
+off = rand(10)
+newoff = rand(5)
+
+@test_throws ArgumentError predict(gm11, newX, offset=newoff)
+
+gm12 = fit(GeneralizedLinearModel, X, Y, Binomial(), offset=off)
+@test_throws ArgumentError predict(gm12, newX)
+@test_approx_eq predict(gm12, newX, offset=newoff) logistic(newX * coef(gm12) .+ newoff)
 
 ## Prediction from DataFrames
 d = convert(DataFrame, X)
 d[:y] = Y
 
-gm12 = fit(GeneralizedLinearModel, y ~ 0 + x1 + x2, d, Binomial())
-@test predict(gm12) == predict(gm12, d[[:x1, :x2]])
-@test predict(gm12) == predict(gm12, d)
+gm13 = fit(GeneralizedLinearModel, y ~ 0 + x1 + x2, d, Binomial())
+@test predict(gm13) == predict(gm13, d[[:x1, :x2]])
+@test predict(gm13) == predict(gm13, d)
 
 newd = convert(DataFrame, newX)
-predict(gm12, newd)
+predict(gm13, newd)


### PR DESCRIPTION
`predict` should allow an offset to be specified. I can't think of a use case where you would want to fit with an offset and predict without, or vice versa, so I am requiring an offset to be specified if the model is fit with one (and vice versa).

Also `StatsBase.predict` for dataframes ([implemented here](https://github.com/JuliaStats/DataFrames.jl/blob/267a69754cb8fed06af4f2bd3475b17d75cf1cfe/src/statsmodels/statsmodel.jl#L68-L75)) currently does not allow additional args. I think changing it to

```julia
function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame, args...; kwargs...)
    # copy terms, removing outcome if present
    newTerms = remove_response(mm.mf.terms)
    # create new model frame/matrix
    newX = ModelMatrix(ModelFrame(newTerms, df)).m
    predict(mm, newX, args...; kwargs...)
end
```
will do the trick.

When this gets merged, I'll open an issue or pull request for DataFrames.
