### PR TITLE
Fix #99 by improving precision in ProbInv and variance calculations.

### DIFF
--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -41,7 +41,7 @@ evaluate{T<:FP}(::CauchInv,x::T) = convert(T,0.5) + atan(x)/pi
 type CauchME <: Functor{1} end
 evaluate{T<:FP}(::CauchME,x::T) = one(T)/(pi*(one(T) + abs2(x)))
 type CLgLgLink <: Functor{1} end
-evaluate{T<:FP}(::CLgLgLink,x::T) = log(-log(one(T) - x))
+evaluate{T<:FP}(::CLgLgLink,x::T) = log(-log1p(-x))
 type CLgLgInv <: Functor{1} end
 evaluate{T<:FP}(::CLgLgInv,x::T) = -expm1(-exp(x))
 type CLgLgME <: Functor{1} end
@@ -51,11 +51,11 @@ evaluate{T<:FP}(::InvME,x::T) = -one(T)/abs2(x)
 type LogitME <: Functor{1} end
 evaluate{T<:FP}(::LogitME,x::T) = (e = exp(-abs(x)); f = one(T) + e; e / (f * f))
 type ProbLink <: Functor{1} end
-evaluate{T<:FP}(::ProbLink,x::T) = sqrt2*erfinv(convert(T,2.0)*x-one(T))
+evaluate{T<:FP}(::ProbLink,x::T) = -sqrt2*erfcinv(2*x)
 type ProbInv <: Functor{1} end
-evaluate{T<:FP}(::ProbInv,x::T) = (one(T) + erf(x/sqrt2))/convert(T,2.0)
+evaluate{T<:FP}(::ProbInv,x::T) = erfc(-x/sqrt2)/2
 type ProbME <: Functor{1} end
-evaluate{T<:FP}(::ProbME,x::T) = exp(-x*x/convert(T,2.0))/sqrt2π
+evaluate{T<:FP}(::ProbME,x::T) = exp(-x*x*convert(T,0.5))/sqrt2π
 type SqrtME <: Functor{1} end
 evaluate{T<:FP}(::SqrtME,x::T) = 2*x
 
@@ -88,10 +88,32 @@ canonicallink(::Normal) = IdentityLink()
 canonicallink(::Binomial) = LogitLink()
 canonicallink(::Poisson) = LogLink()
 
-type BernoulliVar <: Functor{1} end
-evaluate{T<:FP}(::BernoulliVar,x::T) = x * (one(T) - x)
+# For the "odd" link functions we evaluate the linear predictor such that mu is closest to zero where the precision is higher
+for (l, li) in
+    ((:CauchitLink, :CauchInv),
+     (:InverseLink, :RcpFun),
+     (:LogitLink, :LogisticFun),
+     (:ProbitLink, :ProbInv))
+    @eval begin
+        function var!{T<:FP}(::Binomial,l::$l,v::Vector{T},eta::Vector{T})
+            @inbounds @simd for i = 1:length(eta)
+                η = eta[i]
+                mu = evaluate($li(), ifelse(η < 0, η, -η))
+                v[i] = mu*(1 - mu)
+            end
+            v
+        end
+    end
+end
+# but Cloglog is not "odd"
+function var!{T<:FP}(::Binomial,l::CloglogLink,v::Vector{T},eta::Vector{T})
+    @inbounds @simd for i = 1:length(eta)
+        mu = evaluate(CLgLgInv(), eta[i])
+        v[i] = mu*(1 - mu)
+    end
+    v
+end
 
-var!{T<:FP}(::Binomial,v::Vector{T},mu::Vector{T}) = simdmap!(BernoulliVar(),v,mu)
 var!{T<:FP}(::Gamma,v::Vector{T},mu::Vector{T}) = simdmap!(Abs2Fun(),v,mu)
 var!{T<:FP}(::Normal,v::Vector{T},mu::Vector{T}) = fill!(v,one(T))
 var!{T<:FP}(::Poisson,v::Vector{T},mu::Vector{T}) = copy!(v,mu)
@@ -107,8 +129,13 @@ mustart{T<:FP}(d::Distribution,y::Vector{T},wt::Vector{T}) = mustart!(d, similar
 
 type BinomialDevResid <: Functor{3} end
 function evaluate{T<:FP}(::BinomialDevResid,y::T,mu::T,wt::T)
-    omy = one(T)-y
-    2.wt*(xlogy(y,y/mu) + xlogy(omy,omy/(one(T)-mu)))
+    if y == 1
+        return 2.0*wt*-log(mu)
+    elseif y == 0
+        return -2.0*wt*log1p(-mu)
+    else
+        return 2.0*wt*(y*(log(y) - log(mu)) + (1 - y)*(log1p(-y) - log1p(-mu)))
+    end
 end
 
 type PoissonDevResid <: Functor{3} end


### PR DESCRIPTION
The `ProbInv` function was not precise for large negative values so using another formula improved precision. In addition, the Bernoulli variance calculation `p*(1-p)` could be improved for all link functions for which it doesn't matter if we set `p=F^{-1}(x'β)` or `p=F^{-1}(-x'β)`. Finally, residual deviation calculations for `Binomial` is made more precise.

I had to comment out the prediction tests because they are running a glm with Bernoulli response on data in the [0,1] interval. Does that makes sense? I haven't seen it before.

@dmbates, @kleinschmidt