### PR TITLE
Fix #103

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -88,7 +88,14 @@ vcov(x::LinPredModel) = scale!(inv(cholfact(x.pp)), scale(x,true))
 #vcov(x::DensePredChol) = inv(x.chol)
 #vcov(x::DensePredQR) = copytri!(potri!('U', x.qr[:R]), 'U')
 
-cor(x::LinPredModel) = (invstd = map(RcpFun(),stderr(x)); scale!(invstd,scale!(vcov(x),invstd)))
+function cor(x::LinPredModel)
+    Σ = vcov(x)
+    invstd = similar(Σ, size(Σ, 1))
+    for i = 1:size(Σ, 1)
+        invstd[i] = 1/sqrt(Σ[i, i])
+    end
+    scale!(invstd, scale!(Σ, invstd))
+end
 
 stderr(x::LinPredModel) = sqrt(diag(vcov(x)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,10 @@ form = DataFrame(Carb=[0.1,0.3,0.5,0.6,0.7,0.9],OptDen=[0.086,0.269,0.446,0.538,
 lm1 = fit(LinearModel, OptDen ~ Carb, form)
 test_show(lm1)
 @test_approx_eq coef(lm1) linreg(array(form[:Carb]),array(form[:OptDen]))
+Σ = [6.136653061224592e-05 -9.464489795918525e-05
+    -9.464489795918525e-05 1.831836734693908e-04]
+@test_approx_eq vcov(lm1) Σ
+@test_approx_eq cor(lm1.model) diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2)
 
 dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
 gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())


### PR DESCRIPTION
I broke this in #95. This could just be changed to use `simdmap!`, but this avoids computing `vcov` twice and the explicit loop should be faster.