### PR TITLE
Restructuring of factorizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Distributions 0.4.6-
 StatsBase 0.7.1
 Reexport

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -14,16 +14,13 @@ module GLM
     export                              # types
         CauchitLink,
         CloglogLink,
-        DensePred,
-        DensePredQR,
-        DensePredChol,
         GeneralizedLinearModel,
         GlmResp,
         IdentityLink,
         InverseLink,
         LinearModel,
         Link,
-        LinPred,
+        LinFact,
         LinPredModel,
         LogitLink,
         LogLink,
@@ -71,8 +68,7 @@ module GLM
 
     abstract ModResp                   # model response
 
-    abstract LinPred                   # linear predictor in statistical models
-    abstract DensePred <: LinPred      # linear predictor with dense X
+    abstract LinFact{T}                      # factorization of design matrix
     abstract LinPredModel <: RegressionModel # model based on a linear predictor
 
     include("linpred.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -12,5 +12,9 @@ import Base
                 verbose=verbose, maxIter=maxIter, minStepFac=minStepFac, convTol=convTol,
                 start=start))
 
+@deprecate lmc(X, y) fit(LinearModel{Chol}, X, y)
+
 typealias LmMod LinearModel
 typealias GlmMod GeneralizedLinearModel
+typealias DensePredQR DenseQRUnweighted
+typealias DensePredChol DenseCholUnweighted

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,76 +15,114 @@ test_show(lm1)
 @test_approx_eq vcov(lm1) Σ
 @test_approx_eq cor(lm1.model) diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2)
 
-dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
-gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
-test_show(gm1)
-@test_approx_eq deviance(gm1) 5.12914107700115
-@test_approx_eq coef(gm1)[1:3] [3.044522437723423,-0.45425527227759555,-0.29298712468147375]
+# Using Cholesky instead of QR
+lm2 = fit(LinearModel{GLM.Chol}, OptDen ~ Carb, form)
+test_show(lm2)
+@test_approx_eq coef(lm2) coef(lm1)
+@test_approx_eq vcov(lm2) vcov(lm1)
+@test_approx_eq cor(lm2.model) cor(lm1.model)
 
-## Example from http://www.ats.ucla.edu/stat/r/dae/logit.htm
-df = readtable(Pkg.dir("GLM","data","admit.csv.gz"))
-df[:rank] = pool(df[:rank])
+# Sparse matrix
+mf = ModelFrame(OptDen ~ Carb, form)
+X = ModelMatrix(mf).m
+y = model_response(mf)
+lm3 = fit(LinearModel, sparse(X), y)
+test_show(lm3)
+@test_approx_eq coef(lm3) coef(lm1)
+@test_approx_eq vcov(lm3) vcov(lm1)
+@test_approx_eq cor(lm3) cor(lm1.model)
 
-gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial())
-test_show(gm2)
-@test_approx_eq deviance(gm2) 458.5174924758994
-@test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
+# Refitting an existing model
+y = randn(6)
+lm4 = fit(LinearModel, X, y)
+fit!(lm1.model, y)
+fit!(lm2.model, y)
+fit!(lm3, y)
+@test coef(lm1) == coef(lm4)
+@test_approx_eq coef(lm2) coef(lm4)
+@test_approx_eq coef(lm3) coef(lm4)
 
-gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), ProbitLink())
-test_show(gm3)
-@test_approx_eq deviance(gm3) 458.4131713833386
-@test_approx_eq coef(gm3) [-2.3867922998680786,0.0013755394922972369,0.47772908362647015,-0.4154125854823675,-0.8121458010130356,-0.9359047862425298]
+for glmtype in (GeneralizedLinearModel, GeneralizedLinearModel{GLM.QR})
+	dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
+	gm1 = fit(glmtype, Counts ~ Outcome + Treatment, dobson, Poisson())
+	test_show(gm1)
+	@test_approx_eq deviance(gm1) 5.12914107700115
+	@test_approx_eq coef(gm1)[1:3] [3.044522437723423,-0.45425527227759555,-0.29298712468147375]
 
-gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), CauchitLink())
-test_show(gm4)
-@test_approx_eq deviance(gm4) 459.3401112751141
+	## Example from http://www.ats.ucla.edu/stat/r/dae/logit.htm
+	df = readtable(Pkg.dir("GLM","data","admit.csv.gz"))
+	df[:rank] = pool(df[:rank])
 
-gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), CloglogLink())
-test_show(gm5)
-@test_approx_eq deviance(gm5) 458.89439629612616
+	gm2 = fit(glmtype, admit ~ gre + gpa + rank, df, Binomial())
+	test_show(gm2)
+	@test_approx_eq deviance(gm2) 458.5174924758994
+	@test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
 
-## Example with offsets from Venables & Ripley (2002, p.189)
-df = readtable(Pkg.dir("GLM","data","anorexia.csv.gz"))
-df[:Treat] = pool(df[:Treat])
+	gm3 = fit(glmtype, admit ~ gre + gpa + rank, df, Binomial(), ProbitLink())
+	test_show(gm3)
+	@test_approx_eq deviance(gm3) 458.4131713833386
+	@test_approx_eq coef(gm3) [-2.3867922998680786,0.0013755394922972369,0.47772908362647015,-0.4154125854823675,-0.8121458010130356,-0.9359047862425298]
 
-gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, df, Normal(), IdentityLink(), offset=convert(Array, df[:Prewt]))
-test_show(gm6)
-@test_approx_eq deviance(gm6) 3311.262619919613
-@test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
-@test_approx_eq scale(gm6.model, true) 48.6950385282296
-@test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
+	gm4 = fit(glmtype, admit ~ gre + gpa + rank, df, Binomial(), CauchitLink())
+	test_show(gm4)
+	@test_approx_eq deviance(gm4) 459.3401112751141
 
-gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, df, Normal(), LogLink(), offset=convert(Array, df[:Prewt]),
-	      convTol=1e-8)
-test_show(gm7)
-@test_approx_eq deviance(gm7) 3265.207242977156
-@test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
-@test_approx_eq scale(gm7.model, true) 48.01787789178518
-@test_approx_eq stderr(gm7) [0.157167944259695,0.001886285986164,0.022584069426311,0.023882826190166]
+	gm5 = fit(glmtype, admit ~ gre + gpa + rank, df, Binomial(), CloglogLink())
+	test_show(gm5)
+	@test_approx_eq deviance(gm5) 458.89439629612616
 
-## Gamma example from McCullagh & Nelder (1989, pp. 300-2)
-clotting = DataFrame(u = log([5,10,15,20,30,40,60,80,100]),
-                     lot1 = [118,58,42,35,27,25,21,19,18])
-gm8 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma())
-test_show(gm8)
-@test_approx_eq deviance(gm8) 0.01672971517848353
-@test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
-@test_approx_eq scale(gm8.model, true) 0.002446059333495581
-@test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
+	## Example with offsets from Venables & Ripley (2002, p.189)
+	df = readtable(Pkg.dir("GLM","data","anorexia.csv.gz"))
+	df[:Treat] = pool(df[:Treat])
 
-gm9 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
-test_show(gm9)
-@test_approx_eq deviance(gm9) 0.16260829451739
-@test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
-@test_approx_eq scale(gm9.model, true) 0.02435442293561081
-@test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
+	gm6 = fit(glmtype, Postwt ~ Prewt + Treat, df, Normal(), IdentityLink(), offset=convert(Array, df[:Prewt]))
+	test_show(gm6)
+	@test_approx_eq deviance(gm6) 3311.262619919613
+	@test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
+	@test_approx_eq scale(gm6.model, true) 48.6950385282296
+	@test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
 
-gm10 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), IdentityLink(), convTol=1e-8)
-test_show(gm10)
-@test_approx_eq deviance(gm10) 0.60845414895344
-@test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
-@test_approx_eq scale(gm10.model, true) 0.1041772704067886
-@test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
+	gm7 = fit(glmtype, Postwt ~ Prewt + Treat, df, Normal(), LogLink(), offset=convert(Array, df[:Prewt]),
+		      convTol=1e-8)
+	test_show(gm7)
+	@test_approx_eq deviance(gm7) 3265.207242977156
+	@test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
+	@test_approx_eq scale(gm7.model, true) 48.01787789178518
+	@test_approx_eq stderr(gm7) [0.157167944259695,0.001886285986164,0.022584069426311,0.023882826190166]
+
+	## Gamma example from McCullagh & Nelder (1989, pp. 300-2)
+	clotting = DataFrame(u = log([5,10,15,20,30,40,60,80,100]),
+	                     lot1 = [118,58,42,35,27,25,21,19,18])
+	gm8 = fit(glmtype, lot1 ~ u, clotting, Gamma())
+	test_show(gm8)
+	@test_approx_eq deviance(gm8) 0.01672971517848353
+	@test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
+	@test_approx_eq scale(gm8.model, true) 0.002446059333495581
+	@test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
+
+	gm9 = fit(glmtype, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
+	test_show(gm9)
+	@test_approx_eq deviance(gm9) 0.16260829451739
+	@test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
+	@test_approx_eq scale(gm9.model, true) 0.02435442293561081
+	@test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
+
+	gm10 = fit(glmtype, lot1 ~ u, clotting, Gamma(), IdentityLink(), convTol=1e-8)
+	test_show(gm10)
+	@test_approx_eq deviance(gm10) 0.60845414895344
+	@test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
+	@test_approx_eq scale(gm10.model, true) 0.1041772704067886
+	@test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
+
+	# Refitting a GLM
+	clotting[:rand] = [0.0990236, 0.627943, 3.84452, 0.961799, 3.83038, 1.24821, 3.1516, 2.46783, 4.79321]
+	gmnewfit = fit(glmtype, rand ~ u, clotting, Gamma())
+	fit!(gm8.model, clotting[:rand])
+	@test deviance(gm8) == deviance(gmnewfit)
+	@test coef(gm8) == coef(gmnewfit)
+	@test scale(gm8.model) == scale(gmnewfit.model)
+	@test stderr(gm8) == stderr(gmnewfit)
+end
 
 ## Fitting GLMs with sparse matrices
 srand(1)


### PR DESCRIPTION
New functionality:
- Avoid performing an extra Cholesky factorization when fitting a GLM.
- Allow refitting LinearModels with the same factorization but a new `y`. (This was already possible for GeneralizedLinearModels.)
- Allow fitting LinearModels using sparse Cholesky.
- Allow fitting GeneralizedLinearModels using dense QR.
- Implement syntax like `fit(LinearModel{GLM.Chol}, ...)` and `fit(GeneralizedLinearModel{GLM.QR}, ...)` to fit models using alternative factorizations.

Changes to internals:
- Move `beta0`, `delbeta`, and `scratchbeta` (now `curbeta`) to GLM object. These were not really related to the factorizations themselves, and keeping them together with the factorizations required extra fields on each. Since the factorizations now just generate the betas and not the linear predictors, I renamed `LinPred` to `LinFact`.
- Separate `delbeta!` into `factorize!` and `\`/`solve!`. (`solve!` is kind of like `A_ldiv_B!` but may create a new array instead of returning the output, since this is necessary for QR and sparse Cholesky).
- Separate unweighted and weighted LinFact types for Cholesky, to avoid creating unnecessary temporaries for ordinary linear models.
- Require Julia 0.4.

cc @matthieugomez, who may be interested.
