### PR TITLE
Implement fit statistics functions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -123,9 +123,13 @@ These extractors are defined for ``m`` of type
    confidence intervals on the coefficients.  The confidence level,
    ``level``, defaults to 0.95.
 
-.. function:: scale(m, sqr=false) -> Float64
+.. function:: dispersion(m, sqr=false) -> Float64
 
-   Estimate, ``s``, of the residual scale parameter or its square.
+   Estimated dispersion (or scale) parameter for a model's distribution,
+   generally written σ for linear models and ϕ for generalized linear models.
+   It is by definition equal to 1 for Binomial and Poisson families.
+
+   If ``sqr`` is ``true``, the squared parameter is returned.
 
 .. function:: stderr(m) -> Vector{Float64}
 

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -7,7 +7,7 @@ module GLM
     using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel, logit, logistic
     using Distributions: sqrt2, sqrt2π
 
-    import Base: (\), cholfact, convert, cor, scale, show, size
+    import Base: (\), cholfact, convert, cor, show, size
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy, R2, R², adjR2, adjR²
     export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, R2, R², adjR2, adjR²
 

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -8,8 +8,8 @@ module GLM
     using Distributions: sqrt2, sqrt2π
 
     import Base: (\), cholfact, convert, cor, scale, show, size
-    import StatsBase: coef, coeftable, confint, deviance, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy
-    export coef, coeftable, confint, deviance, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response
+    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy, R2, R², adjR2, adjR²
+    export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, R2, R², adjR2, adjR²
 
     export                              # types
         CauchitLink,

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -258,9 +258,16 @@ fit{M<:AbstractGLM}(::Type{M},
 
 glm(X, y, args...; kwargs...) = fit(GeneralizedLinearModel, X, y, args...; kwargs...)
 
-## scale(m) -> estimate, s, of the scale parameter
-## scale(m,true) -> estimate, s^2, of the squared scale parameter
-function scale(m::AbstractGLM, sqr::Bool=false)
+"""
+    dispersion(m::AbstractGLM, sqr::Bool=false)
+
+    Estimated dispersion (or scale) parameter for a model's distribution,
+    generally written σ for linear models and ϕ for generalized linear models.
+    It is by definition equal to 1 for Binomial and Poisson families.
+
+    If `sqr` is `true`, the squared parameter is returned.
+"""
+function dispersion(m::AbstractGLM, sqr::Bool=false)
     wrkwts = m.rr.wrkwts
     wrkresid = m.rr.wrkresid
 

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -114,7 +114,23 @@ function confint(obj::AbstractGLM, level::Real)
 end
 confint(obj::AbstractGLM) = confint(obj, 0.95)
 
-deviance(m::AbstractGLM)  = deviance(m.rr)
+deviance(m::AbstractGLM) = deviance(m.rr)
+
+function loglikelihood(m::AbstractGLM)
+    r = m.rr
+    wts = r.wts
+    y = r.y
+    mu = r.mu
+    ϕ = deviance(m)/sum(wts)
+    d = r.d
+    ll = zero(one(eltype(wts)) * one(loglik_obs(d, y[1], mu[1], wts[1], ϕ)))
+    @inbounds for i in eachindex(y, mu, wts)
+        ll += loglik_obs(d, y[i], mu[i], wts[i], ϕ)
+    end
+    ll
+end
+
+df(x::GeneralizedLinearModel) = dispersion_parameter(x.rr.d) ? length(coef(x)) + 1 : length(coef(x))
 
 function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real,
               convTol::Real, start)

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -87,3 +87,14 @@ end
 devresid(::Gamma, y, μ, wt) = -2wt * (log(y / μ) - (y - μ) / μ)
 devresid(::Normal, y, μ, wt) = wt * abs2(y - μ)
 devresid(::Poisson, y, μ, wt) = 2wt * (xlogy(y, y / μ) - (y - μ))
+
+# Whether a dispersion parameter has to be estimated for a distribution
+dispersion_parameter(::Union{Bernoulli, Binomial, Poisson}) = false
+dispersion_parameter(::Union{Gamma, Normal, InverseGaussian}) = true
+
+# Log-likelihood for an observation
+loglik_obs(::Bernoulli, y, μ, wt, ϕ) = wt*logpdf(Bernoulli(μ), y)
+loglik_obs(::Binomial, y, μ, wt, ϕ) = logpdf(Binomial(wt, μ), y*wt)
+loglik_obs(::Gamma, y, μ, wt, ϕ) = wt*logpdf(Gamma(1/ϕ, μ*ϕ), y)
+loglik_obs(::Normal, y, μ, wt, ϕ) = wt*logpdf(Normal(μ, sqrt(ϕ)), y)
+loglik_obs(::Poisson, y, μ, wt, ϕ) = wt*logpdf(Poisson(μ), y)

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -117,7 +117,7 @@ Base.cholfact!{T}(p::SparsePredChol{T}) = p.chol
 
 invchol(x::DensePred) = inv(cholfact!(x))
 invchol(x::SparsePredChol) = cholfact!(x) \ eye(size(x.X, 2))
-vcov(x::LinPredModel) = scale!(invchol(x.pp), scale(x,true))
+vcov(x::LinPredModel) = scale!(invchol(x.pp), dispersion(x, true))
 
 function cor(x::LinPredModel)
     Σ = vcov(x)

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -134,41 +134,6 @@ function show(io::IO, obj::LinPredModel)
     println(io, "$(typeof(obj)):\n\nCoefficients:\n", coeftable(obj))
 end
 
-## function show(io::IO, obj::GlmMod)
-##     cc = coef(obj)
-##     se = stderr(obj)
-##     zz = cc ./ se
-##     pp = 2.0 * ccdf(Normal(), abs(zz))
-##     @printf("\n%s\n\nCoefficients:\n", obj.fr.formula)
-##     @printf("         Term    Estimate  Std. Error     t value    Pr(>|t|)\n")
-##     N = length(cc)
-##     for i = 1:N
-##         @printf(" %12s%12.5f%12.5f%12.3f%12.3f %-3s\n",
-##                 obj.mm.model_colnames[i],
-##                 cc[i],
-##                 se[i],
-##                 zz[i],
-##                 pp[i],
-##                 p_value_stars(pp[i]))
-##     end
-##     println("---\nSignif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1\n")
-##     @printf("R-squared: %0.4f\n", 0.0) # TODO: obj.r_squared)
-## end
-
-## function p_value_stars(p_value::Float64)
-##     if p_value < 0.001
-##         return "***"
-##     elseif p_value < 0.01
-##         return "**"
-##     elseif p_value < 0.05
-##         return "*"
-##     elseif p_value < 0.1
-##         return "."
-##     else
-##         return " "
-##     end
-## end
-
 ModelFrame(obj::LinPredModel) = obj.fr
 ModelMatrix(obj::LinPredModel) = obj.pp.X
 model_response(obj::LinPredModel) = obj.rr.y

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -145,9 +145,7 @@ function adjR2(obj::LinearModel)
     1 - (1 - R²(obj))*(n-1)/(n-p)
 end
 
-## scale(m) -> estimate, s, of the scale parameter
-## scale(m,true) -> estimate, s^2, of the squared scale parameter
-function scale(x::LinearModel, sqr::Bool=false)
+function dispersion(x::LinearModel, sqr::Bool=false)
     ssqr = deviance(x.rr)/df_residual(x)
     return sqr ? ssqr : sqrt(ssqr)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-DataFrames
+DataFrames 0.6.11

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,52 +16,91 @@ test_show(lm1)
     -9.464489795918525e-05 1.831836734693908e-04]
 @test_approx_eq vcov(lm1) Σ
 @test_approx_eq cor(lm1.model) diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2)
+@test df(lm1) == 3
+@test_approx_eq deviance(lm1) 0.0002992000000000012
+@test_approx_eq loglikelihood(lm1) 21.204842144047973
+@test_approx_eq nulldeviance(lm1) 0.3138488333333334
+@test_approx_eq nullloglikelihood(lm1) 0.33817870295676444
+@test R²(lm1) == R2(lm1)
+@test_approx_eq R²(lm1) 0.9990466748057584
+@test adjR²(lm1) == adjR2(lm1)
+@test_approx_eq adjR²(lm1) 0.998808343507198
+@test_approx_eq AIC(lm1) -36.409684288095946
+@test_approx_eq AICc(lm1) -24.409684288095946
+@test_approx_eq BIC(lm1) -37.03440588041178
 
 dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
 gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
 test_show(gm1)
+@test df(gm1) == 5
 @test_approx_eq deviance(gm1) 5.12914107700115
+@test_approx_eq loglikelihood(gm1) -23.380659200978837
+@test_approx_eq AIC(gm1) 56.76131840195767
+@test_approx_eq AICc(gm1) 76.76131840195768
+@test_approx_eq BIC(gm1) 57.74744128863877
 @test_approx_eq coef(gm1)[1:3] [3.044522437723423,-0.45425527227759555,-0.29298712468147375]
 
 ## Example from http://www.ats.ucla.edu/stat/r/dae/logit.htm
-df = readtable(joinpath(glm_datadir, "admit.csv.gz"))
-df[:rank] = pool(df[:rank])
+admit = readtable(joinpath(glm_datadir, "admit.csv.gz"))
+admit[:rank] = pool(admit[:rank])
 
-gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial())
-test_show(gm2)
-@test_approx_eq deviance(gm2) 458.5174924758994
-@test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
+for distr in (Binomial, Bernoulli)
+    gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, distr())
+    test_show(gm2)
+    @test df(gm2) == 6
+    @test_approx_eq deviance(gm2) 458.5174924758994
+    @test_approx_eq loglikelihood(gm2) -229.25874623794968
+    @test_approx_eq AIC(gm2) 470.51749247589936
+    @test_approx_eq AICc(gm2) 470.7312329339146
+    @test_approx_eq BIC(gm2) 494.4662797585473
+    @test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
+end
 
-gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Bernoulli())
-test_show(gm2)
-@test_approx_eq deviance(gm2) 458.5174924758994
-@test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
-
-gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), ProbitLink())
+gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), ProbitLink())
 test_show(gm3)
+@test df(gm3) == 6
 @test_approx_eq deviance(gm3) 458.4131713833386
+@test_approx_eq loglikelihood(gm3) -229.20658569166932
+@test_approx_eq AIC(gm3) 470.41317138333864
+@test_approx_eq AICc(gm3) 470.6269118413539
+@test_approx_eq BIC(gm3) 494.36195866598655
 @test_approx_eq coef(gm3) [-2.3867922998680786,0.0013755394922972369,0.47772908362647015,-0.4154125854823675,-0.8121458010130356,-0.9359047862425298]
 
-gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), CauchitLink())
+gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CauchitLink())
 test_show(gm4)
+@test df(gm4) == 6
 @test_approx_eq deviance(gm4) 459.3401112751141
+@test_approx_eq loglikelihood(gm4) -229.6700556375571
+@test_approx_eq AIC(gm4) 471.3401112751142
+@test_approx_eq AICc(gm4) 471.5538517331295
+@test_approx_eq BIC(gm4) 495.28889855776214
 
-gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, df, Binomial(), CloglogLink())
+gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CloglogLink())
 test_show(gm5)
+@test df(gm5) == 6
 @test_approx_eq deviance(gm5) 458.89439629612616
+@test_approx_eq loglikelihood(gm5) -229.44719814806314
+@test_approx_eq AIC(gm5) 470.8943962961263
+@test_approx_eq AICc(gm5) 471.1081367541415
+@test_approx_eq BIC(gm5) 494.8431835787742
 
 ## Example with offsets from Venables & Ripley (2002, p.189)
-df = readtable(joinpath(glm_datadir, "anorexia.csv.gz"))
-df[:Treat] = pool(df[:Treat])
+anorexia = readtable(joinpath(glm_datadir, "anorexia.csv.gz"))
+anorexia[:Treat] = pool(anorexia[:Treat])
 
-gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, df, Normal(), IdentityLink(), offset=convert(Array, df[:Prewt]))
+gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), IdentityLink(), offset=convert(Array, anorexia[:Prewt]))
 test_show(gm6)
+@test df(gm6) == 5
 @test_approx_eq deviance(gm6) 3311.262619919613
+@test_approx_eq loglikelihood(gm6) -239.9866487711122
+@test_approx_eq AIC(gm6) 489.9732975422244
+@test_approx_eq AICc(gm6) 490.8823884513153
+@test_approx_eq BIC(gm6) 501.35662813730465
 @test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
 @test_approx_eq scale(gm6.model, true) 48.6950385282296
 @test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
 
-gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, df, Normal(), LogLink(), offset=convert(Array, df[:Prewt]),
+gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), LogLink(), offset=convert(Array, anorexia[:Prewt]),
 	      convTol=1e-8)
 test_show(gm7)
 @test_approx_eq deviance(gm7) 3265.207242977156
@@ -74,24 +113,97 @@ clotting = DataFrame(u = log([5,10,15,20,30,40,60,80,100]),
                      lot1 = [118,58,42,35,27,25,21,19,18])
 gm8 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma())
 test_show(gm8)
-@test_approx_eq deviance(gm8) 0.01672971517848353
+@test df(gm8) == 3
+@test_approx_eq deviance(gm8) 0.016729715178484157
+@test_approx_eq loglikelihood(gm8) -15.994961974777247
+@test_approx_eq AIC(gm8) 37.989923949554495
+@test_approx_eq AICc(gm8) 42.78992394955449
+@test_approx_eq BIC(gm8) 38.58159768156315
 @test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
 @test_approx_eq scale(gm8.model, true) 0.002446059333495581
 @test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
 
 gm9 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
 test_show(gm9)
+@test df(gm9) == 3
 @test_approx_eq deviance(gm9) 0.16260829451739
+@test_approx_eq loglikelihood(gm9) -26.24082810384911
+@test_approx_eq AIC(gm9) 58.48165620769822
+@test_approx_eq AICc(gm9) 63.28165620769822
+@test_approx_eq BIC(gm9) 59.07332993970688
 @test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
 @test_approx_eq scale(gm9.model, true) 0.02435442293561081
 @test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
 
 gm10 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), IdentityLink(), convTol=1e-8)
 test_show(gm10)
+@test df(gm10) == 3
 @test_approx_eq deviance(gm10) 0.60845414895344
+@test_approx_eq loglikelihood(gm10) -32.216072437284176
+@test_approx_eq AIC(gm10) 70.43214487456835
+@test_approx_eq AICc(gm10) 75.23214487456835
+@test_approx_eq BIC(gm10) 71.02381860657701
 @test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
 @test_approx_eq scale(gm10.model, true) 0.1041772704067886
 @test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
+
+# Logistic regression using aggregated data and weights
+admit_agr = DataFrame(count=[28, 97, 93, 55, 33, 54, 28, 12],
+                      admit=repeat([false, true], inner=[4]),
+                      rank=PooledDataArray(repeat([1, 2, 3, 4], outer=[2])))
+for distr in (Binomial, Bernoulli)
+    gm14 = fit(GeneralizedLinearModel, admit ~ rank, admit_agr, distr(), wts=Vector{Float64}(admit_agr[:count]))
+    @test df(gm14) == 4
+    @test nobs(gm14) == 400
+    @test_approx_eq deviance(gm14) 474.9667184280627
+    @test_approx_eq loglikelihood(gm14) -237.48335921403134
+    @test_approx_eq AIC(gm14) 482.96671842822883
+    @test_approx_eq AICc(gm14) 483.0679842510136
+    @test_approx_eq BIC(gm14) 498.9325766164946
+    @test_approx_eq_eps coef(gm14) [0.16430305129127593,-0.7500299832244263,-1.364697929944679,-1.6867286645732025] 1e-5
+end
+
+# Logistic regression using aggregated data with proportions of successes and weights
+admit_agr2 = DataFrame(count=[61, 151, 121, 67],
+                       admit=[33, 54, 28, 12],
+                       rank=PooledDataArray([1, 2, 3, 4]))
+admit_agr2[:p] = admit_agr2[:admit]./admit_agr2[:count]
+
+gm15 = fit(GeneralizedLinearModel, p ~ rank, admit_agr2, Binomial(), wts=Vector{Float64}(admit_agr2[:count]))
+test_show(gm15)
+@test df(gm15) == 4
+@test nobs(gm15) == 400
+@test_approx_eq deviance(gm15) -2.4424906541753456e-15
+@test_approx_eq loglikelihood(gm15) -9.50254433604239
+@test_approx_eq AIC(gm15) 27.00508867208478
+@test_approx_eq AICc(gm15) 27.106354494869592
+@test_approx_eq BIC(gm15) 42.970946860516705
+@test_approx_eq coef(gm15) [0.1643030512912767,-0.7500299832303851,-1.3646980342693287,-1.6867295867357475]
+
+# Weighted Gamma example (weights are totally made up)
+gm16 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
+test_show(gm16)
+@test df(gm16) == 3
+@test nobs(gm16) == 32.7
+@test_approx_eq deviance(gm16) 0.03933389380881689
+@test_approx_eq loglikelihood(gm16) -43.35907878769152
+@test_approx_eq AIC(gm16) 92.71815757538305
+@test_approx_eq AICc(gm16) 93.55439450918095
+@test_approx_eq BIC(gm16) 97.18028280909267
+@test_approx_eq coef(gm16) [-0.017217012615523237,0.015649040411276433]
+
+# Weighted Poisson example (weights are totally made up)
+gm17 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson(),
+           wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
+test_show(gm17)
+@test df(gm17) == 5
+@test_approx_eq deviance(gm17) 17.699857821414266
+@test_approx_eq loglikelihood(gm17) -84.57429468506352
+@test_approx_eq AIC(gm17) 179.14858937012704
+@test_approx_eq AICc(gm17) 181.39578038136298
+@test_approx_eq BIC(gm17) 186.5854647596431
+@test_approx_eq coef(gm17) [3.1218557035404793,  -0.5270435906931427,-0.40300384148562746,
+                           -0.017850203824417415,-0.03507851122782909]
 
 ## Fitting GLMs with sparse matrices
 srand(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,7 @@ test_show(gm6)
 @test_approx_eq AICc(gm6) 490.8823884513153
 @test_approx_eq BIC(gm6) 501.35662813730465
 @test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
-@test_approx_eq scale(gm6.model, true) 48.6950385282296
+@test_approx_eq GLM.dispersion(gm6.model, true) 48.6950385282296
 @test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
 
 gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), LogLink(), offset=convert(Array, anorexia[:Prewt]),
@@ -105,7 +105,7 @@ gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), Lo
 test_show(gm7)
 @test_approx_eq deviance(gm7) 3265.207242977156
 @test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
-@test_approx_eq scale(gm7.model, true) 48.01787789178518
+@test_approx_eq GLM.dispersion(gm7.model, true) 48.01787789178518
 @test_approx_eq stderr(gm7) [0.157167944259695,0.001886285986164,0.022584069426311,0.023882826190166]
 
 ## Gamma example from McCullagh & Nelder (1989, pp. 300-2)
@@ -120,7 +120,7 @@ test_show(gm8)
 @test_approx_eq AICc(gm8) 42.78992394955449
 @test_approx_eq BIC(gm8) 38.58159768156315
 @test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
-@test_approx_eq scale(gm8.model, true) 0.002446059333495581
+@test_approx_eq GLM.dispersion(gm8.model, true) 0.002446059333495581
 @test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
 
 gm9 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
@@ -132,7 +132,7 @@ test_show(gm9)
 @test_approx_eq AICc(gm9) 63.28165620769822
 @test_approx_eq BIC(gm9) 59.07332993970688
 @test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
-@test_approx_eq scale(gm9.model, true) 0.02435442293561081
+@test_approx_eq GLM.dispersion(gm9.model, true) 0.02435442293561081
 @test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
 
 gm10 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), IdentityLink(), convTol=1e-8)
@@ -144,7 +144,7 @@ test_show(gm10)
 @test_approx_eq AICc(gm10) 75.23214487456835
 @test_approx_eq BIC(gm10) 71.02381860657701
 @test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
-@test_approx_eq scale(gm10.model, true) 0.1041772704067886
+@test_approx_eq GLM.dispersion(gm10.model, true) 0.1041772704067886
 @test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
 
 # Logistic regression using aggregated data and weights


### PR DESCRIPTION
This implements functions to be added to StatsBase (https://github.com/JuliaStats/StatsBase.jl/pull/146): `loglikelihood`, `nullloglikelihood`, `nulldeviance`, `df`. It also adds an `adjR²` function, and changes `nobs` to return the sum of weights where it makes sense. Tests for fitting models using weights are also introduced. Fixes https://github.com/JuliaStats/GLM.jl/issues/74.

Issues to tackle:
- [x] Computing the R² is only supported for `LinearModel` currently, as for GLMs we need to compute the deviance of the null model. (Could be added later.) UPDATE: Will add later in another PR, this isn't essential.
- [x] Is it OK that `nobs` returned the sum of weights when they are present? This is the only logical choice for binomial on aggregated data (see `gm11` in the tests). This is the same behavior as Stata, but R returns the number of rows instead. This only makes sense for frequency weights, and this will have to be improved when we support more weights types. (Anyway I think this whole idea of number of independent observations is hard to define correctly, and the BIC is a fragile measure because of that.) UPDATE: I've made this change since currently the code treats weights as frequency weights (contrary to R).
- [x] Should the log-likelihood of individual observations be computed directly using formulas, or is calling `logpdf` fine? I don't expect `loglikelihood` to be a bottleneck. UPDATE: Let's keep it that way, at least for now.
- [x] Should `adjR²` be defined in `StatsBase` together with `R²`? I actually think it should, but the small glitch is that there is no generalized adjusted R² which is exactly equal to the classical adjusted R² for linear regression. The closest variant, the adjusted McFadden R², is slightly different. This means a linear regression would give slightly different results when fit via `lm` than when fit via `glm`. Not a big deal, though. UPDATE: I fixed this by defining `adjR2` in StatsBase, but requiring a `variant` argument for GLMs. That way, there is no inconsistency depending on the way the model is fitted.
- [x] Add tests for weighted Gamma and Poisson.
- [x] Add tests for `nullloglikelihood`.
- [x] Export `scale` under a different name (`sigma` or `dispersion`?). UPDATE: I went with `dispersion`.

To use this, you need https://github.com/JuliaStats/StatsBase.jl/pull/146. Also, after fitting a model from a `DataFrame`, you need to call the functions on `obj.model` rather than on `obj` directly (or to add code to DataFrames.jl to delegate the functions to that object). I'll make a PR to fix that when we have agreed on the API.

(Tests will fail until https://github.com/JuliaStats/StatsBase.jl/pull/146 and https://github.com/JuliaStats/DataFrames.jl/pull/921 are merged and releases tagged.)