### PR TITLE
Use eachindex(x) instead of 1:length(x) and other cleanup

### DIFF
--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,5 +1,5 @@
-using GLM, DataFrames, Compat
-glm(y ~ 1, DataFrame(y = float64(bitrand(10))), Binomial())
+using GLM, DataFrames
+glm(y ~ 1, DataFrame(y = float(bitrand(10))), Binomial())
 
 n = 2_500_000; srand(1234321)
 df2 = DataFrame(x1 = rand(Normal(), n),
@@ -12,8 +12,10 @@ beta = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 ## Create linear predictor and mean response
 eta = mm.m * beta;
 mu = [linkinv(LogitLink(), x) for x in eta]
-y = map(Float64, rand(n) .< mu);        # simulate observed responses
+y = Float64[rand() < μ for μ in mu];        # simulate observed responses
 
 gm6 = glm(mm.m, y, Binomial())
 @time glm(mm.m, y, Binomial());
-# Profile.print()
+#@profile glm(mm.m, y, Binomial());
+#using ProfileView
+#ProfileView.view()

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -37,33 +37,22 @@ module GLM
 
                                         # functions
         canonicallink,  # canonical link function for a distribution
-        contr_treatment,# treatment contrasts
         delbeta!,       # evaluate the increment in the coefficient vector
         deviance,       # deviance of fitted and observed responses
         devresid,       # vector of squared deviance residuals
-        drsum,          # sum of squared deviance residuals
         formula,        # extract the formula from a model
         glm,            # general interface
-        linkfun!,       # mutating link function
         linkfun,        # link function mapping mu to eta, the linear predictor
-        linkinv!,       # mutating inverse link
         linkinv,        # inverse link mapping eta to mu
         linpred,        # linear predictor
         linpred!,       # update the linear predictor
         lm,             # linear model (QR factorization)
-        lmc,            # linear model (Cholesky factorization)          
-        mueta!,         # mutating derivative of inverse link
+        lmc,            # linear model (Cholesky factorization)
         mueta,          # derivative of inverse link
         mustart,        # derive starting values for the mu vector
         nobs,           # total number of observations
-        objective,      # the objective function in fitting a model
         predict,        # make predictions
-        sqrtwrkwt,      # square root of the working weights
-        stderr,         # standard errors of the coefficients
         updatemu!,      # update the response type from the linear predictor
-        var!,           # mutating variance function
-        wrkresid!,      # mutating working residuals function
-        wrkresid,       # extract the working residuals              
         wrkresp         # working response
 
     typealias FP AbstractFloat

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -44,13 +44,13 @@ function updatemu!{T<:FPVector}(r::GlmResp{T}, linPr::T)
     wrkresid = r.wrkresid
     devresidv = r.devresid
 
-    if length(offset) == length(eta)
-        broadcast!(+, eta, linPr, offset)
-    else
+    if isempty(offset)
         copy!(eta, linPr)
+    else
+        broadcast!(+, eta, linPr, offset)
     end
 
-    @inbounds @simd for i = 1:length(eta)
+    @inbounds @simd for i = eachindex(eta)
         η = eta[i]
 
         # apply the inverse link function generating the mean vector (μ) from the linear predictor (η)
@@ -68,25 +68,21 @@ function updatemu!{T<:FPVector}(r::GlmResp{T}, linPr::T)
 end
 
 function wrkresp(r::GlmResp)
-    if length(r.offset) > 0
-        tmp = r.eta - r.offset
-        broadcast!(+, tmp, tmp, r.wrkresid)
-    else
-        r.eta + r.wrkresid
-    end
+    tmp = r.eta + r.wrkresid
+    isempty(r.offset) ? tmp : broadcast!(-, tmp, tmp, r.offset)
 end
 
 function wrkwt!(r::GlmResp)
     wrkwts = r.wrkwts
     mueta = r.mueta
     var = r.var
-    if length(r.wts) == 0
-        @simd for i = 1:length(r.var)
+    if isempty(r.wts)
+        @simd for i = eachindex(r.var)
             @inbounds wrkwts[i] = abs2(mueta[i])/var[i]
         end
     else
         wts = r.wts
-        @simd for i = 1:length(r.var)
+        @simd for i = eachindex(r.var)
             @inbounds wrkwts[i] = wts[i] * abs2(mueta[i])/var[i]
         end
     end
@@ -176,12 +172,12 @@ function initialeta!(dist::UnivariateDistribution, link::Link,
                      eta::AbstractVector, y::AbstractVector, wts::AbstractVector,
                      off::AbstractVector)
     length(eta) == length(y) == length(wts) || throw(DimensionMismatch("argument lengths do not match"))
-    @inbounds @simd for i = 1:length(y)
+    @inbounds @simd for i = eachindex(y)
         μ = mustart(dist, y[i], wts[i])
         eta[i] = linkfun(link, μ)
     end
     if !isempty(off)
-        @inbounds @simd for i = 1:length(eta)
+        @inbounds @simd for i = eachindex(eta)
             eta[i] -= off[i]
         end
     end
@@ -243,7 +239,7 @@ function scale(m::AbstractGLM, sqr::Bool=false)
     end
 
     s = zero(eltype(wrkwts))
-    @inbounds @simd for i = 1:length(wrkwts)
+    @inbounds @simd for i = eachindex(wrkwts)
         s += wrkwts[i]*abs2(wrkresid[i])
     end
     s /= df_residual(m)

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -1,4 +1,4 @@
-using Base.Cartesian
+#using Base.Cartesian
 
 abstract Link             # Link types define linkfun!, linkinv!, and mueta!
 

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -1,5 +1,3 @@
-#using Base.Cartesian
-
 abstract Link             # Link types define linkfun!, linkinv!, and mueta!
 
 type CauchitLink <: Link end

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -8,7 +8,7 @@ linpred(p::LinPred, f::Real=1.) = linpred!(Array(eltype(p.X), size(p.X, 1)), p, 
 function installbeta!(p::LinPred, f::Real=1.)
     beta0 = p.beta0
     delbeta = p.delbeta
-    @inbounds for i = eachindex(beta0)
+    @inbounds for i = eachindex(beta0,delbeta)
         beta0[i] += delbeta[i]*f
         delbeta[i] = 0
     end
@@ -45,22 +45,11 @@ DensePredChol{T<:BlasReal}(X::Matrix{T}) =
     DensePredChol(X, zeros(T, size(X, 2)), zeros(T, size(X, 2)), zeros(T, size(X, 2)), cholfact!(X'X), similar(X))
 cholpred(X::Matrix) = DensePredChol(X)
 
-# if VERSION >= v"0.4.0-dev+4356"   # GLM requires julia 0.4
-    cholfactors(c::Cholesky) = c.factors
-#else
-#    cholfactors(c::Cholesky) = c.UL
-#end
+cholfactors(c::Cholesky) = c.factors
 Base.LinAlg.cholfact!{T<:FP}(p::DensePredChol{T}) = p.chol
-
-#if v"0.4.0-dev+122" <= VERSION < v"0.4.0-dev+4356"
-#    Base.LinAlg.cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky{T,Matrix{T},:U}(copy(p.qr[:R]))
-#    Base.LinAlg.cholfact{T<:FP}(p::DensePredChol{T}) = (c = p.chol; typeof(c)(copy(c.UL)))
-#    Base.LinAlg.cholfact!{T<:FP}(p::DensePredQR{T}) = Cholesky{T,Matrix{T},:U}(p.qr[:R])
-#else
-    Base.LinAlg.cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky(copy(p.qr[:R]), 'U')
-    Base.LinAlg.cholfact{T<:FP}(p::DensePredChol{T}) = (c = p.chol; Cholesky(copy(cholfactors(c)), c.uplo))
-    Base.LinAlg.cholfact!{T<:FP}(p::DensePredQR{T}) = Cholesky(p.qr[:R], 'U')
-#end
+Base.LinAlg.cholfact{T<:FP}(p::DensePredQR{T}) = Cholesky(copy(p.qr[:R]), 'U')
+Base.LinAlg.cholfact{T<:FP}(p::DensePredChol{T}) = (c = p.chol; Cholesky(copy(cholfactors(c)), c.uplo))
+Base.LinAlg.cholfact!{T<:FP}(p::DensePredQR{T}) = Cholesky(p.qr[:R], 'U')
 
 function delbeta!{T<:BlasReal}(p::DensePredChol{T}, r::Vector{T})
     A_ldiv_B!(p.chol, At_mul_B!(p.delbeta, p.X, r))
@@ -89,14 +78,10 @@ function SparsePredChol{T}(X::SparseMatrixCSC{T})
 end
 cholpred(X::SparseMatrixCSC) = SparsePredChol(X)
 
-@eval function delbeta!{T}(p::SparsePredChol{T}, r::Vector{T}, wt::Vector{T})
+function delbeta!{T}(p::SparsePredChol{T}, r::Vector{T}, wt::Vector{T})
     scr = scale!(p.scratch, wt, p.X)
     XtWX = p.Xt*scr
-    c = p.chol = $(if VERSION >= v"0.4.0-dev+3307"
-        :(cholfact(Symmetric{eltype(XtWX),typeof(XtWX)}(XtWX, 'L')))
-    else
-        :(cholfact(scale!(XtWX + XtWX', convert(eltype(XtWX), 1/2))))
-    end)
+    c = p.chol = cholfact(Symmetric{eltype(XtWX),typeof(XtWX)}(XtWX, 'L'))
     p.delbeta = c\Ac_mul_B!(p.delbeta, scr, r)
 end
 
@@ -112,8 +97,6 @@ df_residual(x::@compat(Union{DensePred,SparsePredChol})) = size(x.X, 1) - length
 invchol(x::DensePred) = inv(cholfact!(x))
 invchol(x::SparsePredChol) = cholfact!(x)\eye(size(x.X, 2))
 vcov(x::LinPredModel) = scale!(invchol(x.pp), scale(x,true))
-#vcov(x::DensePredChol) = inv(x.chol)
-#vcov(x::DensePredQR) = copytri!(potri!('U', x.qr[:R]), 'U')
 
 function cor(x::LinPredModel)
     Σ = vcov(x)

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -44,7 +44,7 @@ function residuals(r::LmResp)
     else
         wts = r.wts
         resid = similar(y)
-        @simd for i = eachindex(r)
+        @simd for i = eachindex(resid,y,mu,wts)
             @inbounds resid[i] = (y[i] - mu[i])*sqrt(wts[i])
         end
         resid

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -25,11 +25,11 @@ function deviance(r::LmResp)
     wts = r.wts
     v = zero(eltype(y))+zero(eltype(y))*zero(eltype(wts))
     if isempty(wts)
-        @inbounds @simd for i = eachindex(y)
+        @inbounds @simd for i = eachindex(y,mu)
             v += abs2(y[i] - mu[i])
         end
     else
-        @inbounds @simd for i = eachindex(y)
+        @inbounds @simd for i = eachindex(y,mu,wts)
             v += abs2(y[i] - mu[i])*wts[i]
         end
     end

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -25,11 +25,11 @@ function deviance(r::LmResp)
     wts = r.wts
     v = zero(eltype(y))+zero(eltype(y))*zero(eltype(wts))
     if isempty(wts)
-        @inbounds @simd for i = 1:length(y)
+        @inbounds @simd for i = eachindex(y)
             v += abs2(y[i] - mu[i])
         end
     else
-        @inbounds @simd for i = 1:length(y)
+        @inbounds @simd for i = eachindex(y)
             v += abs2(y[i] - mu[i])*wts[i]
         end
     end
@@ -44,7 +44,7 @@ function residuals(r::LmResp)
     else
         wts = r.wts
         resid = similar(y)
-        @simd for i = 1:length(r)
+        @simd for i = eachindex(r)
             @inbounds resid[i] = (y[i] - mu[i])*sqrt(wts[i])
         end
         resid


### PR DESCRIPTION
This PR is rather simple - primarily replacing instances of `1:length(x)` by `eachindex(x)` which, IIUC, should be better with subarrays, if we choose to use them.  I also removed the conditional code for versions less than v"0.4" because "julia 0.4" is now part of the `REQUIRE` file.

The next thing I plan to look at is flagging the canonical link function for a distribution to take advantage in the `wrkwts!` method of the fact that r.mueta == r.var for the canonical link.