### PR TITLE
Ensure non-zero starting μ for Gamma

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 Distributions 0.4.6-
 StatsBase 0.8.0
+StatsFuns
 Reexport
 Compat 0.2.12-

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -5,6 +5,7 @@ module GLM
     using Base.LinAlg.BLAS: gemm!, gemv!
     using Base.LinAlg: QRCompactWY, Cholesky
     using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel, logit, logistic
+    using StatsFuns: xlogx, xlogy
     using Distributions: sqrt2, sqrt2π
 
     import Base: (\), cholfact, convert, cor, show, size
@@ -52,7 +53,7 @@ module GLM
         mustart,        # derive starting values for the mu vector
         nobs,           # total number of observations
         predict,        # make predictions
-        updatemu!,      # update the response type from the linear predictor
+        updateμ!,      # update the response type from the linear predictor
         wrkresp         # working response
 
     typealias FP AbstractFloat

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -63,7 +63,7 @@ glmvar(::Poisson, ::Link, μ, η) = μ
 
 mustart(::Bernoulli, y, wt) = (y + oftype(y, 0.5)) / 2
 mustart(::Binomial, y, wt) = (wt * y + oftype(y, 0.5)) / (wt + one(y))
-mustart(::Gamma, y, wt) = y
+mustart(::Gamma, y, wt) = y == 0 ? oftype(y, 0.1) : y  # add a test
 mustart(::Normal, y, wt) = y
 mustart(::Poisson, y, wt) = y + oftype(y, 0.1)
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -16,13 +16,13 @@ end
 convert{V<:FPVector}(::Type{LmResp{V}}, y::V) =
     LmResp{V}(zeros(y), similar(y, 0), similar(y, 0), y)
 
-function updatemu!{V<:FPVector}(r::LmResp{V}, linPr::V)
+function updateμ!{V<:FPVector}(r::LmResp{V}, linPr::V)
     n = length(linPr)
     length(r.y) == n || error("length(linPr) is $n, should be $(length(r.y))")
     length(r.offset) == 0 ? copy!(r.mu, linPr) : broadcast!(+, r.mu, linPr, r.offset)
     deviance(r)
 end
-updatemu!{V<:FPVector}(r::LmResp{V}, linPr) = updatemu!(r, convert(V, vec(linPr)))
+updateμ!{V<:FPVector}(r::LmResp{V}, linPr) = updateμ!(r, convert(V, vec(linPr)))
 
 function deviance(r::LmResp)
     y = r.y
@@ -105,7 +105,7 @@ function fit{LmRespT<:LmResp,LinPredT<:LinPred, T<:FP}(::Type{LinearModel{LmResp
     rr = LmRespT(y)
     pp = LinPredT(X)
     installbeta!(delbeta!(pp, rr.y))
-    updatemu!(rr, linpred(pp, 0.0))
+    updateμ!(rr, linpred(pp, 0.0))
     LinearModel(rr, pp)
 end
 function fit(::Type{LinearModel}, X::AbstractMatrix, y::Vector)


### PR DESCRIPTION
A simple change to avoid starting estimates for μ being zero with a Gamma distribution.  Usually the `InverseLink` or the `LogLink` are used with a Gamma distribution.  If the starting estimate for an element of  μ is zero everything falls down. 
