### PR TITLE
Update functions deprecated in StatsBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 Distributions 0.4.6-
-StatsBase 0.8.0
+StatsBase 0.8.3
 Reexport
 Compat 0.2.12-

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -8,8 +8,8 @@ module GLM
     using Distributions: sqrt2, sqrt2π
 
     import Base: (\), cholfact, convert, cor, show, size
-    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy, R2, R², adjR2, adjR²
-    export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, R2, R², adjR2, adjR²
+    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy, r2, r², adjr2, adjr²
+    export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, r2, r², adjr2, adjr²
 
     export                              # types
         CauchitLink,

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -136,13 +136,13 @@ nulldeviance(obj::LinearModel) = nulldeviance(obj.rr)
 loglikelihood(obj::LinearModel) = loglikelihood(obj.rr)
 nullloglikelihood(obj::LinearModel) = nullloglikelihood(obj.rr)
 
-R2(obj::LinearModel) = 1 - deviance(obj)/nulldeviance(obj)
+r2(obj::LinearModel) = 1 - deviance(obj)/nulldeviance(obj)
 
-function adjR2(obj::LinearModel)
+function adjr2(obj::LinearModel)
     n = nobs(obj)
     # df() includes the dispersion parameter
     p = df(obj) - 1
-    1 - (1 - R²(obj))*(n-1)/(n-p)
+    1 - (1 - r²(obj))*(n-1)/(n-p)
 end
 
 function dispersion(x::LinearModel, sqr::Bool=false)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-DataFrames 0.6.11
+DataFrames 0.7.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using Base.Test, DataFrames, GLM
 
 function test_show(x)
-	io = IOBuffer()
-	show(io, x)
+    io = IOBuffer()
+    show(io, x)
 end
 
 const glm_datadir = joinpath(dirname(@__FILE__), "..", "data")
@@ -21,13 +21,13 @@ test_show(lm1)
 @test_approx_eq loglikelihood(lm1) 21.204842144047973
 @test_approx_eq nulldeviance(lm1) 0.3138488333333334
 @test_approx_eq nullloglikelihood(lm1) 0.33817870295676444
-@test R²(lm1) == R2(lm1)
-@test_approx_eq R²(lm1) 0.9990466748057584
-@test adjR²(lm1) == adjR2(lm1)
-@test_approx_eq adjR²(lm1) 0.998808343507198
-@test_approx_eq AIC(lm1) -36.409684288095946
-@test_approx_eq AICc(lm1) -24.409684288095946
-@test_approx_eq BIC(lm1) -37.03440588041178
+@test r²(lm1) == r2(lm1)
+@test_approx_eq r²(lm1) 0.9990466748057584
+@test adjr²(lm1) == adjr2(lm1)
+@test_approx_eq adjr²(lm1) 0.998808343507198
+@test_approx_eq aic(lm1) -36.409684288095946
+@test_approx_eq aicc(lm1) -24.409684288095946
+@test_approx_eq bic(lm1) -37.03440588041178
 
 dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
 gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
@@ -35,9 +35,9 @@ test_show(gm1)
 @test df(gm1) == 5
 @test_approx_eq deviance(gm1) 5.12914107700115
 @test_approx_eq loglikelihood(gm1) -23.380659200978837
-@test_approx_eq AIC(gm1) 56.76131840195767
-@test_approx_eq AICc(gm1) 76.76131840195768
-@test_approx_eq BIC(gm1) 57.74744128863877
+@test_approx_eq aic(gm1) 56.76131840195767
+@test_approx_eq aicc(gm1) 76.76131840195768
+@test_approx_eq bic(gm1) 57.74744128863877
 @test_approx_eq coef(gm1)[1:3] [3.044522437723423,-0.45425527227759555,-0.29298712468147375]
 
 ## Example from http://www.ats.ucla.edu/stat/r/dae/logit.htm
@@ -50,9 +50,9 @@ for distr in (Binomial, Bernoulli)
     @test df(gm2) == 6
     @test_approx_eq deviance(gm2) 458.5174924758994
     @test_approx_eq loglikelihood(gm2) -229.25874623794968
-    @test_approx_eq AIC(gm2) 470.51749247589936
-    @test_approx_eq AICc(gm2) 470.7312329339146
-    @test_approx_eq BIC(gm2) 494.4662797585473
+    @test_approx_eq aic(gm2) 470.51749247589936
+    @test_approx_eq aicc(gm2) 470.7312329339146
+    @test_approx_eq bic(gm2) 494.4662797585473
     @test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
 end
 
@@ -61,9 +61,9 @@ test_show(gm3)
 @test df(gm3) == 6
 @test_approx_eq deviance(gm3) 458.4131713833386
 @test_approx_eq loglikelihood(gm3) -229.20658569166932
-@test_approx_eq AIC(gm3) 470.41317138333864
-@test_approx_eq AICc(gm3) 470.6269118413539
-@test_approx_eq BIC(gm3) 494.36195866598655
+@test_approx_eq aic(gm3) 470.41317138333864
+@test_approx_eq aicc(gm3) 470.6269118413539
+@test_approx_eq bic(gm3) 494.36195866598655
 @test_approx_eq coef(gm3) [-2.3867922998680786,0.0013755394922972369,0.47772908362647015,-0.4154125854823675,-0.8121458010130356,-0.9359047862425298]
 
 gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CauchitLink())
@@ -71,18 +71,18 @@ test_show(gm4)
 @test df(gm4) == 6
 @test_approx_eq deviance(gm4) 459.3401112751141
 @test_approx_eq loglikelihood(gm4) -229.6700556375571
-@test_approx_eq AIC(gm4) 471.3401112751142
-@test_approx_eq AICc(gm4) 471.5538517331295
-@test_approx_eq BIC(gm4) 495.28889855776214
+@test_approx_eq aic(gm4) 471.3401112751142
+@test_approx_eq aicc(gm4) 471.5538517331295
+@test_approx_eq bic(gm4) 495.28889855776214
 
 gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CloglogLink())
 test_show(gm5)
 @test df(gm5) == 6
 @test_approx_eq deviance(gm5) 458.89439629612616
 @test_approx_eq loglikelihood(gm5) -229.44719814806314
-@test_approx_eq AIC(gm5) 470.8943962961263
-@test_approx_eq AICc(gm5) 471.1081367541415
-@test_approx_eq BIC(gm5) 494.8431835787742
+@test_approx_eq aic(gm5) 470.8943962961263
+@test_approx_eq aicc(gm5) 471.1081367541415
+@test_approx_eq bic(gm5) 494.8431835787742
 
 ## Example with offsets from Venables & Ripley (2002, p.189)
 anorexia = readtable(joinpath(glm_datadir, "anorexia.csv.gz"))
@@ -93,15 +93,15 @@ test_show(gm6)
 @test df(gm6) == 5
 @test_approx_eq deviance(gm6) 3311.262619919613
 @test_approx_eq loglikelihood(gm6) -239.9866487711122
-@test_approx_eq AIC(gm6) 489.9732975422244
-@test_approx_eq AICc(gm6) 490.8823884513153
-@test_approx_eq BIC(gm6) 501.35662813730465
+@test_approx_eq aic(gm6) 489.9732975422244
+@test_approx_eq aicc(gm6) 490.8823884513153
+@test_approx_eq bic(gm6) 501.35662813730465
 @test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
 @test_approx_eq GLM.dispersion(gm6.model, true) 48.6950385282296
 @test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
 
 gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), LogLink(), offset=convert(Array, anorexia[:Prewt]),
-	      convTol=1e-8)
+          convTol=1e-8)
 test_show(gm7)
 @test_approx_eq deviance(gm7) 3265.207242977156
 @test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
@@ -116,9 +116,9 @@ test_show(gm8)
 @test df(gm8) == 3
 @test_approx_eq deviance(gm8) 0.016729715178484157
 @test_approx_eq loglikelihood(gm8) -15.994961974777247
-@test_approx_eq AIC(gm8) 37.989923949554495
-@test_approx_eq AICc(gm8) 42.78992394955449
-@test_approx_eq BIC(gm8) 38.58159768156315
+@test_approx_eq aic(gm8) 37.989923949554495
+@test_approx_eq aicc(gm8) 42.78992394955449
+@test_approx_eq bic(gm8) 38.58159768156315
 @test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
 @test_approx_eq GLM.dispersion(gm8.model, true) 0.002446059333495581
 @test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
@@ -128,9 +128,9 @@ test_show(gm9)
 @test df(gm9) == 3
 @test_approx_eq deviance(gm9) 0.16260829451739
 @test_approx_eq loglikelihood(gm9) -26.24082810384911
-@test_approx_eq AIC(gm9) 58.48165620769822
-@test_approx_eq AICc(gm9) 63.28165620769822
-@test_approx_eq BIC(gm9) 59.07332993970688
+@test_approx_eq aic(gm9) 58.48165620769822
+@test_approx_eq aicc(gm9) 63.28165620769822
+@test_approx_eq bic(gm9) 59.07332993970688
 @test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
 @test_approx_eq GLM.dispersion(gm9.model, true) 0.02435442293561081
 @test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
@@ -140,9 +140,9 @@ test_show(gm10)
 @test df(gm10) == 3
 @test_approx_eq deviance(gm10) 0.60845414895344
 @test_approx_eq loglikelihood(gm10) -32.216072437284176
-@test_approx_eq AIC(gm10) 70.43214487456835
-@test_approx_eq AICc(gm10) 75.23214487456835
-@test_approx_eq BIC(gm10) 71.02381860657701
+@test_approx_eq aic(gm10) 70.43214487456835
+@test_approx_eq aicc(gm10) 75.23214487456835
+@test_approx_eq bic(gm10) 71.02381860657701
 @test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
 @test_approx_eq GLM.dispersion(gm10.model, true) 0.1041772704067886
 @test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
@@ -157,9 +157,9 @@ for distr in (Binomial, Bernoulli)
     @test nobs(gm14) == 400
     @test_approx_eq deviance(gm14) 474.9667184280627
     @test_approx_eq loglikelihood(gm14) -237.48335921403134
-    @test_approx_eq AIC(gm14) 482.96671842822883
-    @test_approx_eq AICc(gm14) 483.0679842510136
-    @test_approx_eq BIC(gm14) 498.9325766164946
+    @test_approx_eq aic(gm14) 482.96671842822883
+    @test_approx_eq aicc(gm14) 483.0679842510136
+    @test_approx_eq bic(gm14) 498.9325766164946
     @test_approx_eq_eps coef(gm14) [0.16430305129127593,-0.7500299832244263,-1.364697929944679,-1.6867286645732025] 1e-5
 end
 
@@ -175,9 +175,9 @@ test_show(gm15)
 @test nobs(gm15) == 400
 @test_approx_eq deviance(gm15) -2.4424906541753456e-15
 @test_approx_eq loglikelihood(gm15) -9.50254433604239
-@test_approx_eq AIC(gm15) 27.00508867208478
-@test_approx_eq AICc(gm15) 27.106354494869592
-@test_approx_eq BIC(gm15) 42.970946860516705
+@test_approx_eq aic(gm15) 27.00508867208478
+@test_approx_eq aicc(gm15) 27.106354494869592
+@test_approx_eq bic(gm15) 42.970946860516705
 @test_approx_eq coef(gm15) [0.1643030512912767,-0.7500299832303851,-1.3646980342693287,-1.6867295867357475]
 
 # Weighted Gamma example (weights are totally made up)
@@ -187,9 +187,9 @@ test_show(gm16)
 @test nobs(gm16) == 32.7
 @test_approx_eq deviance(gm16) 0.03933389380881689
 @test_approx_eq loglikelihood(gm16) -43.35907878769152
-@test_approx_eq AIC(gm16) 92.71815757538305
-@test_approx_eq AICc(gm16) 93.55439450918095
-@test_approx_eq BIC(gm16) 97.18028280909267
+@test_approx_eq aic(gm16) 92.71815757538305
+@test_approx_eq aicc(gm16) 93.55439450918095
+@test_approx_eq bic(gm16) 97.18028280909267
 @test_approx_eq coef(gm16) [-0.017217012615523237,0.015649040411276433]
 
 # Weighted Poisson example (weights are totally made up)
@@ -199,9 +199,9 @@ test_show(gm17)
 @test df(gm17) == 5
 @test_approx_eq deviance(gm17) 17.699857821414266
 @test_approx_eq loglikelihood(gm17) -84.57429468506352
-@test_approx_eq AIC(gm17) 179.14858937012704
-@test_approx_eq AICc(gm17) 181.39578038136298
-@test_approx_eq BIC(gm17) 186.5854647596431
+@test_approx_eq aic(gm17) 179.14858937012704
+@test_approx_eq aicc(gm17) 181.39578038136298
+@test_approx_eq bic(gm17) 186.5854647596431
 @test_approx_eq coef(gm17) [3.1218557035404793,  -0.5270435906931427,-0.40300384148562746,
                            -0.017850203824417415,-0.03507851122782909]
 


### PR DESCRIPTION
I bumped the StatsBase requirement to 0.8.3, in which `R2`, `adjR2`, `AIC`, `AICc`, and `BIC` have been deprecated in favor of their lowercase equivalents.