### PR TITLE
Import from StatsFuns instead of StatsBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 Distributions 0.4.6-
 StatsBase 0.8.3
+StatsFuns 0.3.0
 Reexport
 Compat 0.2.12-

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -4,11 +4,13 @@ module GLM
     using Base.LinAlg.LAPACK: potrf!, potrs!
     using Base.LinAlg.BLAS: gemm!, gemv!
     using Base.LinAlg: QRCompactWY, Cholesky
-    using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel, logit, logistic
+    using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel
+    using StatsFuns: logit, logistic
     using Distributions: sqrt2, sqrt2π
 
     import Base: (\), cholfact, convert, cor, show, size
-    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, xlogy, r2, r², adjr2, adjr²
+    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, r2, r², adjr2, adjr²
+    import StatsFuns: xlogy
     export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, r2, r², adjr2, adjr²
 
     export                              # types


### PR DESCRIPTION
These are defined in `StatsFuns` but `StatsBase` is importing and exporting them. Hopefully `StatsBase` will soon not depend on `StatsFuns` anymore so we want to use the right source here.