### PR TITLE
Specialized update methods for canonical links.

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -52,7 +52,7 @@ module GLM
         mustart,        # derive starting values for the mu vector
         nobs,           # total number of observations
         predict,        # make predictions
-        updatemu!,      # update the response type from the linear predictor
+        updateμ!,      # update the response type from the linear predictor
         wrkresp         # working response
 
     typealias FP AbstractFloat

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -12,7 +12,7 @@ type GlmResp{V<:FPVector,D<:UnivariateDistribution,L<:Link} <: ModResp       # r
 end
 
 function GlmResp{V<:FPVector, D, L}(y::V, d::D, l::L, η::V, μ::V, off::V, wts::V)
-    if d == Binomial
+    if d == Binomial()
         for yy in y
             0. <= yy <= 1. || throw(ArgumentError("$yy in y is not in [0,1]"))
         end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -119,7 +119,7 @@ function updateμ!{T,D,L}(r::GlmResp{T,D,L})
         dμdη = mueta(L(), ηi)
         yi = y[i]
         wrkres[i] = (yi - μi)/dμdη
-        dres[i] = devresid(r.d, yi, μi, one(yi))
+        dres[i] = devresid(r.d, yi, μi)
         wrkwt[i] = abs2(dμdη) / max(eps(), glmvar(r.d, L(), μi, ηi))
     end
 end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -26,7 +26,7 @@ type GlmResp{V<:FPVector,D<:UnivariateDistribution,L<:Link} <: ModResp       # r
         lo = length(off)
         lo == 0 || lo == n || error("offset must have length $n or length 0")
         res = new(y,d,l,similar(y),eta,mu,similar(y),off,similar(y),wts,similar(y),similar(y))
-        updatemu!(res, eta)
+        updateμ!(res, eta)
         res
     end
 end
@@ -34,7 +34,7 @@ end
 # returns the sum of the squared deviance residuals
 deviance(r::GlmResp) = sum(r.devresid)
 
-function updatemu!{T<:FPVector}(r::GlmResp{T}, linPr::T)
+function updateμ!{T<:FPVector}(r::GlmResp{T}, linPr::T)
     y = r.y
     dist = r.d
     link = r.l
@@ -144,11 +144,11 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
         copy!(p.beta0, start)
         fill!(p.delbeta, 0)
         linpred!(lp, p, 0)
-        updatemu!(r, lp)
+        updateμ!(r, lp)
     else
         delbeta!(p, wrkresp(r), wrkwt!(r))
         linpred!(lp, p)
-        updatemu!(r, lp)
+        updateμ!(r, lp)
         installbeta!(p)
     end
     devold = deviance(m)
@@ -158,7 +158,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
         try
             delbeta!(p, r.wrkresid, wrkwt!(r))
             linpred!(lp, p)
-            updatemu!(r, lp)
+            updateμ!(r, lp)
             dev = deviance(m)
         catch e
             isa(e, DomainError) ? (dev = Inf) : rethrow(e)
@@ -167,7 +167,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
             f /= 2.
             f > minStepFac || error("step-halving failed at beta0 = $(p.beta0)")
             try
-                updatemu!(r, linpred(p, f))
+                updateμ!(r, linpred(p, f))
                 dev = deviance(m)
             catch e
                 isa(e, DomainError) ? (dev = Inf) : rethrow(e)
@@ -216,7 +216,7 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
     isa(wts, Void) || copy!(r.wts, wts)
     isa(offset, Void) || copy!(r.offset, offset)
     initialeta!(r.d, r.l, r.eta, r.y, r.wts, r.offset)
-    updatemu!(r, r.eta)
+    updateμ!(r, r.eta)
     fill!(m.pp.beta0, 0)
     m.fit = false
     if dofit

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -63,7 +63,7 @@ glmvar(::Poisson, ::Link, μ, η) = μ
 
 mustart(::Bernoulli, y, wt) = (y + oftype(y, 0.5)) / 2
 mustart(::Binomial, y, wt) = (wt * y + oftype(y, 0.5)) / (wt + one(y))
-mustart(::Gamma, y, wt) = y
+mustart(::Gamma, y, wt) = y == 0 ? oftype(y, 0.1) : y
 mustart(::Normal, y, wt) = y
 mustart(::Poisson, y, wt) = y + oftype(y, 0.1)
 

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -21,8 +21,8 @@ linkfun(::IdentityLink, μ) = μ
 linkinv(::IdentityLink, η) = η
 mueta(::IdentityLink, η) = 1
 
-linkfun(::InverseLink, μ) = 1 / μ
-linkinv(::InverseLink, η) = 1 / η
+linkfun(::InverseLink, μ) = inv(μ)
+linkinv(::InverseLink, η) = inv(η)
 mueta(::InverseLink, η) = -inv(abs2(η))
 
 linkfun(::LogitLink, μ) = logit(μ)
@@ -39,7 +39,7 @@ mueta(::LogLink, η) = exp(η)
 
 linkfun(::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
 linkinv(::ProbitLink, η) = erfc(-η / sqrt2) / 2
-mueta(::ProbitLink, η) = exp(-η^2 / 2) / sqrt2π
+mueta(::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
 
 linkfun(::SqrtLink, μ) = sqrt(μ)
 linkinv(::SqrtLink, η) = abs2(η)
@@ -67,26 +67,26 @@ mustart(::Gamma, y, wt) = y
 mustart(::Normal, y, wt) = y
 mustart(::Poisson, y, wt) = y + oftype(y, 0.1)
 
-function devresid(::Bernoulli, y, μ, wt)
+function devresid(::Bernoulli, y, μ)
     if y == 1
-        return -2 * wt * log(μ)
+        return -2 * log(μ)
     elseif y == 0
-        return -2 * wt * log1p(-μ)
+        return -2 * log1p(-μ)
     end
     throw(ArgumentError("y should be 0 or 1 (got $y)"))
 end
-function devresid(::Binomial, y, μ, wt)
+function devresid(::Binomial, y, μ)
     if y == 1
-        return -2 * wt * log(μ)
+        return -2 * log(μ)
     elseif y == 0
-        return -2 * wt * log1p(-μ)
+        return -2 * log1p(-μ)
     else
-        return 2 * wt * (y * (log(y) - log(μ)) + (1 - y)*(log1p(-y) - log1p(-μ)))
+        return 2 * (y * (log(y) - log(μ)) + (1 - y)*(log1p(-y) - log1p(-μ)))
     end
 end
-devresid(::Gamma, y, μ, wt) = -2wt * (log(y / μ) - (y - μ) / μ)
-devresid(::Normal, y, μ, wt) = wt * abs2(y - μ)
-devresid(::Poisson, y, μ, wt) = 2wt * (xlogy(y, y / μ) - (y - μ))
+devresid(::Gamma, y, μ) = -2 * (log(y / μ) - (y - μ) / μ)
+devresid(::Normal, y, μ) = abs2(y - μ)
+devresid(::Poisson, y, μ) = 2 * (xlogy(y, y / μ) - (y - μ))
 
 # Whether a dispersion parameter has to be estimated for a distribution
 dispersion_parameter(::Union{Bernoulli, Binomial, Poisson}) = false

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -16,13 +16,13 @@ end
 convert{V<:FPVector}(::Type{LmResp{V}}, y::V) =
     LmResp{V}(zeros(y), similar(y, 0), similar(y, 0), y)
 
-function updatemu!{V<:FPVector}(r::LmResp{V}, linPr::V)
+function updateμ!{V<:FPVector}(r::LmResp{V}, linPr::V)
     n = length(linPr)
     length(r.y) == n || error("length(linPr) is $n, should be $(length(r.y))")
     length(r.offset) == 0 ? copy!(r.mu, linPr) : broadcast!(+, r.mu, linPr, r.offset)
     deviance(r)
 end
-updatemu!{V<:FPVector}(r::LmResp{V}, linPr) = updatemu!(r, convert(V, vec(linPr)))
+updateμ!{V<:FPVector}(r::LmResp{V}, linPr) = updateμ!(r, convert(V, vec(linPr)))
 
 function deviance(r::LmResp)
     y = r.y
@@ -105,7 +105,7 @@ function fit{LmRespT<:LmResp,LinPredT<:LinPred, T<:FP}(::Type{LinearModel{LmResp
     rr = LmRespT(y)
     pp = LinPredT(X)
     installbeta!(delbeta!(pp, rr.y))
-    updatemu!(rr, linpred(pp, 0.0))
+    updateμ!(rr, linpred(pp, 0.0))
     LinearModel(rr, pp)
 end
 function fit(::Type{LinearModel}, X::AbstractMatrix, y::Vector)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,7 +219,7 @@ admit_agr2[:p] = admit_agr2[:admit] ./ admit_agr2[:count]
     test_show(gm15)
     @test df(gm15) == 4
     @test nobs(gm15) == 400
-    @test isapprox(deviance(gm15), -2.4424906541753456e-15, atol = 1e-18)
+    @test isapprox(deviance(gm15), -2.4424906541753456e-15, rtol = 1e-7)
     @test isapprox(loglikelihood(gm15), -9.50254433604239)
     @test isapprox(aic(gm15), 27.00508867208478)
     @test isapprox(aicc(gm15), 27.106354494869592)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,257 +8,314 @@ end
 const glm_datadir = joinpath(dirname(@__FILE__), "..", "data")
 
 ## Formaldehyde data from the R Datasets package
-form = DataFrame(Carb=[0.1,0.3,0.5,0.6,0.7,0.9],OptDen=[0.086,0.269,0.446,0.538,0.626,0.782])
-lm1 = fit(LinearModel, OptDen ~ Carb, form)
-test_show(lm1)
-@test_approx_eq coef(lm1) collect(linreg(convert(Array, form[:Carb]), convert(Array, form[:OptDen])))
-Σ = [6.136653061224592e-05 -9.464489795918525e-05
-    -9.464489795918525e-05 1.831836734693908e-04]
-@test_approx_eq vcov(lm1) Σ
-@test_approx_eq cor(lm1.model) diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2)
-@test df(lm1) == 3
-@test_approx_eq deviance(lm1) 0.0002992000000000012
-@test_approx_eq loglikelihood(lm1) 21.204842144047973
-@test_approx_eq nulldeviance(lm1) 0.3138488333333334
-@test_approx_eq nullloglikelihood(lm1) 0.33817870295676444
-@test r²(lm1) == r2(lm1)
-@test_approx_eq r²(lm1) 0.9990466748057584
-@test adjr²(lm1) == adjr2(lm1)
-@test_approx_eq adjr²(lm1) 0.998808343507198
-@test_approx_eq aic(lm1) -36.409684288095946
-@test_approx_eq aicc(lm1) -24.409684288095946
-@test_approx_eq bic(lm1) -37.03440588041178
+form = DataFrame(Any[[0.1,0.3,0.5,0.6,0.7,0.9],[0.086,0.269,0.446,0.538,0.626,0.782]],
+    [:Carb, :OptDen])
 
-dobson = DataFrame(Counts=[18.,17,15,20,10,20,25,13,12], Outcome=gl(3,1,9), Treatment=gl(3,3))
-gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
-test_show(gm1)
-@test df(gm1) == 5
-@test_approx_eq deviance(gm1) 5.12914107700115
-@test_approx_eq loglikelihood(gm1) -23.380659200978837
-@test_approx_eq aic(gm1) 56.76131840195767
-@test_approx_eq aicc(gm1) 76.76131840195768
-@test_approx_eq bic(gm1) 57.74744128863877
-@test_approx_eq coef(gm1)[1:3] [3.044522437723423,-0.45425527227759555,-0.29298712468147375]
+@testset "lm" begin
+    lm1 = fit(LinearModel, OptDen ~ Carb, form)
+    test_show(lm1)
+    @test isapprox(coef(lm1), collect(linreg(form[:Carb], form[:OptDen])))
+    Σ = [6.136653061224592e-05 -9.464489795918525e-05
+        -9.464489795918525e-05 1.831836734693908e-04]
+    @test isapprox(vcov(lm1), Σ)
+    @test isapprox(cor(lm1.model), diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2))
+    @test df(lm1) == 3
+    @test isapprox(deviance(lm1), 0.0002992000000000012)
+    @test isapprox(loglikelihood(lm1), 21.204842144047973)
+    @test isapprox(nulldeviance(lm1), 0.3138488333333334)
+    @test isapprox(nullloglikelihood(lm1), 0.33817870295676444)
+    @test r²(lm1) == r2(lm1)
+    @test isapprox(r²(lm1), 0.9990466748057584)
+    @test adjr²(lm1) == adjr2(lm1)
+    @test isapprox(adjr²(lm1), 0.998808343507198)
+    @test isapprox(aic(lm1), -36.409684288095946)
+    @test isapprox(aicc(lm1), -24.409684288095946)
+    @test isapprox(bic(lm1), -37.03440588041178)
+end
+
+dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
+    Outcome = pool(repeat(["A", "B", "C"], outer = 3)),
+    Treatment = pool(repeat(["a","b", "c"], inner = 3)))
+
+@testset "Poisson GLM" begin
+    gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
+    test_show(gm1)
+    @test df(gm1) == 5
+    @test isapprox(deviance(gm1), 5.12914107700115, rtol = 1e-7)
+    @test isapprox(loglikelihood(gm1), -23.380659200978837, rtol = 1e-7)
+    @test isapprox(aic(gm1), 56.76131840195767)
+    @test isapprox(aicc(gm1), 76.76131840195768)
+    @test isapprox(bic(gm1), 57.74744128863877)
+    @test isapprox(coef(gm1)[1:3],
+        [3.044522437723423,-0.45425527227759555,-0.29298712468147375])
+end
 
 ## Example from http://www.ats.ucla.edu/stat/r/dae/logit.htm
 admit = readtable(joinpath(glm_datadir, "admit.csv.gz"))
 admit[:rank] = pool(admit[:rank])
 
-for distr in (Binomial, Bernoulli)
-    gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, distr())
-    test_show(gm2)
-    @test df(gm2) == 6
-    @test_approx_eq deviance(gm2) 458.5174924758994
-    @test_approx_eq loglikelihood(gm2) -229.25874623794968
-    @test_approx_eq aic(gm2) 470.51749247589936
-    @test_approx_eq aicc(gm2) 470.7312329339146
-    @test_approx_eq bic(gm2) 494.4662797585473
-    @test_approx_eq coef(gm2) [-3.9899786606380734,0.0022644256521549043,0.8040374535155766,-0.6754428594116577,-1.3402038117481079,-1.5514636444657492]
+@testset "Binomial, Bernoulli, LogitLink" begin
+    for distr in (Binomial, Bernoulli)
+        gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, distr())
+        test_show(gm2)
+        @test df(gm2) == 6
+        @test isapprox(deviance(gm2), 458.5174924758994)
+        @test isapprox(loglikelihood(gm2), -229.25874623794968)
+        @test isapprox(aic(gm2), 470.51749247589936)
+        @test isapprox(aicc(gm2), 470.7312329339146)
+        @test isapprox(bic(gm2), 494.4662797585473)
+        @test isapprox(coef(gm2),
+            [-3.9899786606380734, 0.0022644256521549043, 0.8040374535155766,
+            -0.6754428594116577, -1.3402038117481079,-1.5514636444657492])
+    end
 end
 
-gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), ProbitLink())
-test_show(gm3)
-@test df(gm3) == 6
-@test_approx_eq deviance(gm3) 458.4131713833386
-@test_approx_eq loglikelihood(gm3) -229.20658569166932
-@test_approx_eq aic(gm3) 470.41317138333864
-@test_approx_eq aicc(gm3) 470.6269118413539
-@test_approx_eq bic(gm3) 494.36195866598655
-@test_approx_eq coef(gm3) [-2.3867922998680786,0.0013755394922972369,0.47772908362647015,-0.4154125854823675,-0.8121458010130356,-0.9359047862425298]
+@testset "Bernoulli ProbitLink" begin
+    gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
+        Binomial(), ProbitLink())
+    test_show(gm3)
+    @test df(gm3) == 6
+    @test isapprox(deviance(gm3), 458.4131713833386)
+    @test isapprox(loglikelihood(gm3), -229.20658569166932)
+    @test isapprox(aic(gm3), 470.41317138333864)
+    @test isapprox(aicc(gm3), 470.6269118413539)
+    @test isapprox(bic(gm3), 494.36195866598655)
+    @test isapprox(coef(gm3),
+        [-2.3867922998680786, 0.0013755394922972369, 0.47772908362647015,
+        -0.4154125854823675, -0.8121458010130356, -0.9359047862425298])
+end
 
-gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CauchitLink())
-test_show(gm4)
-@test df(gm4) == 6
-@test_approx_eq deviance(gm4) 459.3401112751141
-@test_approx_eq loglikelihood(gm4) -229.6700556375571
-@test_approx_eq aic(gm4) 471.3401112751142
-@test_approx_eq aicc(gm4) 471.5538517331295
-@test_approx_eq bic(gm4) 495.28889855776214
+@testset "Bernoulli CauchitLink" begin
+    gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
+        Binomial(), CauchitLink())
+    test_show(gm4)
+    @test df(gm4) == 6
+    @test isapprox(deviance(gm4), 459.3401112751141)
+    @test isapprox(loglikelihood(gm4), -229.6700556375571)
+    @test isapprox(aic(gm4), 471.3401112751142)
+    @test isapprox(aicc(gm4), 471.5538517331295)
+    @test isapprox(bic(gm4), 495.28889855776214)
+end
 
-gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, Binomial(), CloglogLink())
-test_show(gm5)
-@test df(gm5) == 6
-@test_approx_eq deviance(gm5) 458.89439629612616
-@test_approx_eq loglikelihood(gm5) -229.44719814806314
-@test_approx_eq aic(gm5) 470.8943962961263
-@test_approx_eq aicc(gm5) 471.1081367541415
-@test_approx_eq bic(gm5) 494.8431835787742
+@testset "Bernoulli CloglogLink" begin
+    gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
+        Binomial(), CloglogLink())
+    test_show(gm5)
+    @test df(gm5) == 6
+    @test isapprox(deviance(gm5), 458.89439629612616)
+    @test isapprox(loglikelihood(gm5), -229.44719814806314)
+    @test isapprox(aic(gm5), 470.8943962961263)
+    @test isapprox(aicc(gm5), 471.1081367541415)
+    @test isapprox(bic(gm5), 494.8431835787742)
+end
 
 ## Example with offsets from Venables & Ripley (2002, p.189)
 anorexia = readtable(joinpath(glm_datadir, "anorexia.csv.gz"))
 anorexia[:Treat] = pool(anorexia[:Treat])
 
-gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), IdentityLink(), offset=convert(Array, anorexia[:Prewt]))
-test_show(gm6)
-@test df(gm6) == 5
-@test_approx_eq deviance(gm6) 3311.262619919613
-@test_approx_eq loglikelihood(gm6) -239.9866487711122
-@test_approx_eq aic(gm6) 489.9732975422244
-@test_approx_eq aicc(gm6) 490.8823884513153
-@test_approx_eq bic(gm6) 501.35662813730465
-@test_approx_eq coef(gm6) [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188]
-@test_approx_eq GLM.dispersion(gm6.model, true) 48.6950385282296
-@test_approx_eq stderr(gm6) [13.3909581420259,0.1611823618518,1.8934926069669,2.1333359226431]
+@testset "Offset" begin
+    gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia,
+        Normal(), IdentityLink(), offset=Array(anorexia[:Prewt]))
+    test_show(gm6)
+    @test df(gm6) == 5
+    @test isapprox(deviance(gm6), 3311.262619919613)
+    @test isapprox(loglikelihood(gm6), -239.9866487711122)
+    @test isapprox(aic(gm6), 489.9732975422244)
+    @test isapprox(aicc(gm6), 490.8823884513153)
+    @test isapprox(bic(gm6), 501.35662813730465)
+    @test isapprox(coef(gm6),
+        [49.7711090149846,-0.5655388496391,-4.0970655280729,4.5630626529188])
+    @test isapprox(GLM.dispersion(gm6.model, true), 48.6950385282296)
+    @test isapprox(stderr(gm6),
+        [13.3909581420259, 0.1611823618518, 1.8934926069669, 2.1333359226431])
+end
 
-gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), LogLink(), offset=convert(Array, anorexia[:Prewt]),
-          convTol=1e-8)
-test_show(gm7)
-@test_approx_eq deviance(gm7) 3265.207242977156
-@test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
-@test_approx_eq GLM.dispersion(gm7.model, true) 48.017753573192266
-@test_approx_eq_eps stderr(gm7) [0.15716774,0.0018862835,0.02258404,0.023882795] 1e-6
+@testset "Normal LogLink offset" begin
+    gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia,
+        Normal(), LogLink(), offset=Array(anorexia[:Prewt]), convTol=1e-8)
+    test_show(gm7)
+    @test isapprox(deviance(gm7), 3265.207242977156)
+    @test isapprox(coef(gm7),
+        [3.992326787835955, -0.994452693131178, -0.050698258703974, 0.051494029957641])
+    @test isapprox(GLM.dispersion(gm7.model, true), 48.017753573192266)
+    @test isapprox(stderr(gm7), [0.15716774, 0.0018862835, 0.02258404, 0.023882795], atol=1e-6)
+end
 
 ## Gamma example from McCullagh & Nelder (1989, pp. 300-2)
 clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
                      lot1 = [118,58,42,35,27,25,21,19,18])
-gm8 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma())
-test_show(gm8)
-@test df(gm8) == 3
-@test_approx_eq deviance(gm8) 0.016729715178484157
-@test_approx_eq loglikelihood(gm8) -15.994961974777247
-@test_approx_eq aic(gm8) 37.989923949554495
-@test_approx_eq aicc(gm8) 42.78992394955449
-@test_approx_eq bic(gm8) 38.58159768156315
-@test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
-@test_approx_eq_eps GLM.dispersion(gm8.model, true) 0.002446059333495581 1e-6
-@test_approx_eq_eps stderr(gm8) [0.00092754223,0.000414957683] 1e-6
 
-gm9 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
-test_show(gm9)
-@test df(gm9) == 3
-@test_approx_eq deviance(gm9) 0.16260829451739
-@test_approx_eq loglikelihood(gm9) -26.24082810384911
-@test_approx_eq aic(gm9) 58.48165620769822
-@test_approx_eq aicc(gm9) 63.28165620769822
-@test_approx_eq bic(gm9) 59.07332993970688
-@test_approx_eq coef(gm9) [5.50322528458221,-0.60191617825971]
-@test_approx_eq GLM.dispersion(gm9.model, true) 0.02435442293561081
-@test_approx_eq stderr(gm9) [0.19030107482720,0.05530784660144]
+@testset "Gamma InverseLink" begin
+    gm8 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma())
+    test_show(gm8)
+    @test df(gm8) == 3
+    @test isapprox(deviance(gm8), 0.016729715178484157)
+    @test isapprox(loglikelihood(gm8), -15.994961974777247)
+    @test isapprox(aic(gm8), 37.989923949554495)
+    @test isapprox(aicc(gm8), 42.78992394955449)
+    @test isapprox(bic(gm8), 38.58159768156315)
+    @test isapprox(coef(gm8), [-0.01655438172784895,0.01534311491072141])
+    @test isapprox(GLM.dispersion(gm8.model, true), 0.002446059333495581, atol=1e-6)
+    @test isapprox(stderr(gm8), [0.00092754223, 0.000414957683], atol=1e-6)
+end
 
-gm10 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), IdentityLink(), convTol=1e-8)
-test_show(gm10)
-@test df(gm10) == 3
-@test_approx_eq deviance(gm10) 0.60845414895344
-@test_approx_eq loglikelihood(gm10) -32.216072437284176
-@test_approx_eq aic(gm10) 70.43214487456835
-@test_approx_eq aicc(gm10) 75.23214487456835
-@test_approx_eq bic(gm10) 71.02381860657701
-@test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
-@test_approx_eq_eps GLM.dispersion(gm10.model, true) 0.10417373 1e-6
-@test_approx_eq_eps stderr(gm10) [17.864084,4.297895] 1e-4
+@testset "Gamma LogLink" begin
+    gm9 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(), LogLink(),
+        convTol=1e-8)
+    test_show(gm9)
+    @test df(gm9) == 3
+    @test isapprox(deviance(gm9), 0.16260829451739)
+    @test isapprox(loglikelihood(gm9), -26.24082810384911)
+    @test isapprox(aic(gm9), 58.48165620769822)
+    @test isapprox(aicc(gm9), 63.28165620769822)
+    @test isapprox(bic(gm9), 59.07332993970688)
+    @test isapprox(coef(gm9), [5.50322528458221, -0.60191617825971])
+    @test isapprox(GLM.dispersion(gm9.model, true), 0.02435442293561081)
+    @test isapprox(stderr(gm9), [0.19030107482720, 0.05530784660144])
+end
+
+@testset "Gamma IdentityLink" begin
+    gm10 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(), IdentityLink(),
+        convTol=1e-8)
+    test_show(gm10)
+    @test df(gm10) == 3
+    @test isapprox(deviance(gm10), 0.60845414895344)
+    @test isapprox(loglikelihood(gm10), -32.216072437284176)
+    @test isapprox(aic(gm10), 70.43214487456835)
+    @test isapprox(aicc(gm10), 75.23214487456835)
+    @test isapprox(bic(gm10), 71.02381860657701)
+    @test isapprox(coef(gm10), [99.250446880986, -18.374324929002])
+    @test isapprox(GLM.dispersion(gm10.model, true), 0.10417373, atol=1e-6)
+    @test isapprox(stderr(gm10), [17.864084, 4.297895], atol=1e-4)
+end
+
 # Logistic regression using aggregated data and weights
-admit_agr = DataFrame(count=[28, 97, 93, 55, 33, 54, 28, 12],
-                      admit=repeat([false, true], inner=[4]),
-                      rank=PooledDataArray(repeat([1, 2, 3, 4], outer=[2])))
-for distr in (Binomial, Bernoulli)
-    gm14 = fit(GeneralizedLinearModel, admit ~ rank, admit_agr, distr(), wts=Vector{Float64}(admit_agr[:count]))
-    @test df(gm14) == 4
-    @test nobs(gm14) == 400
-    @test_approx_eq deviance(gm14) 474.9667184280627
-    @test_approx_eq loglikelihood(gm14) -237.48335921403134
-    @test_approx_eq aic(gm14) 482.96671842822883
-    @test_approx_eq aicc(gm14) 483.0679842510136
-    @test_approx_eq bic(gm14) 498.9325766164946
-    @test_approx_eq_eps coef(gm14) [0.16430305129127593,-0.7500299832244263,-1.364697929944679,-1.6867286645732025] 1e-5
+admit_agr = DataFrame(count = [28., 97, 93, 55, 33, 54, 28, 12],
+                      admit = repeat([false, true], inner=[4]),
+                      rank = pool(repeat([1, 2, 3, 4], outer=[2])))
+
+@testset "Aggregated Binomial LogitLink" begin
+    for distr in (Binomial, Bernoulli)
+        gm14 = fit(GeneralizedLinearModel, admit ~ rank, admit_agr, distr(), wts=Array(admit_agr[:count]))
+        @test df(gm14) == 4
+        @test nobs(gm14) == 400
+        @test isapprox(deviance(gm14), 474.9667184280627)
+        @test isapprox(loglikelihood(gm14), -237.48335921403134)
+        @test isapprox(aic(gm14), 482.96671842822883)
+        @test isapprox(aicc(gm14), 483.0679842510136)
+        @test isapprox(bic(gm14), 498.9325766164946)
+        @test isapprox(coef(gm14),
+            [0.164303051291, -0.7500299832, -1.36469792994, -1.68672866457], atol=1e-5)
+    end
 end
 
 # Logistic regression using aggregated data with proportions of successes and weights
-admit_agr2 = DataFrame(count=[61, 151, 121, 67],
-                       admit=[33, 54, 28, 12],
-                       rank=PooledDataArray([1, 2, 3, 4]))
-admit_agr2[:p] = Array(admit_agr2[:admit]) ./ Array(admit_agr2[:count])
+admit_agr2 = DataFrame(Any[[61., 151, 121, 67], [33., 54, 28, 12], pool([1, 2, 3, 4])],
+    [:count, :admit, :rank])
+admit_agr2[:p] = admit_agr2[:admit] ./ admit_agr2[:count]
 
-gm15 = fit(GeneralizedLinearModel, p ~ rank, admit_agr2, Binomial(), wts=Vector{Float64}(admit_agr2[:count]))
-test_show(gm15)
-@test df(gm15) == 4
-@test nobs(gm15) == 400
-@test_approx_eq deviance(gm15) -2.4424906541753456e-15
-@test_approx_eq loglikelihood(gm15) -9.50254433604239
-@test_approx_eq aic(gm15) 27.00508867208478
-@test_approx_eq aicc(gm15) 27.106354494869592
-@test_approx_eq bic(gm15) 42.970946860516705
-@test_approx_eq coef(gm15) [0.1643030512912767,-0.7500299832303851,-1.3646980342693287,-1.6867295867357475]
+@testset "Binomial LogitLink aggregated" begin
+    gm15 = fit(GeneralizedLinearModel, p ~ rank, admit_agr2, Binomial(), wts=admit_agr2[:count])
+    test_show(gm15)
+    @test df(gm15) == 4
+    @test nobs(gm15) == 400
+    @test isapprox(deviance(gm15), -2.4424906541753456e-15, atol = 1e-18)
+    @test isapprox(loglikelihood(gm15), -9.50254433604239)
+    @test isapprox(aic(gm15), 27.00508867208478)
+    @test isapprox(aicc(gm15), 27.106354494869592)
+    @test isapprox(bic(gm15), 42.970946860516705)
+    @test isapprox(coef(gm15),
+        [0.1643030512912767, -0.7500299832303851, -1.3646980342693287, -1.6867295867357475])
+end
 
 # Weighted Gamma example (weights are totally made up)
-gm16 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
-test_show(gm16)
-@test df(gm16) == 3
-@test nobs(gm16) == 32.7
-@test_approx_eq deviance(gm16) 0.03933389380881689
-@test_approx_eq loglikelihood(gm16) -43.35907878769152
-@test_approx_eq aic(gm16) 92.71815757538305
-@test_approx_eq aicc(gm16) 93.55439450918095
-@test_approx_eq bic(gm16) 97.18028280909267
-@test_approx_eq coef(gm16) [-0.017217012615523237,0.015649040411276433]
+@testset "Gamma InverseLink Weights" begin
+    gm16 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(),
+        wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
+    test_show(gm16)
+    @test df(gm16) == 3
+    @test nobs(gm16) == 32.7
+    @test isapprox(deviance(gm16), 0.03933389380881689)
+    @test isapprox(loglikelihood(gm16), -43.35907878769152)
+    @test isapprox(aic(gm16), 92.71815757538305)
+    @test isapprox(aicc(gm16), 93.55439450918095)
+    @test isapprox(bic(gm16), 97.18028280909267)
+    @test isapprox(coef(gm16), [-0.017217012615523237, 0.015649040411276433])
+end
 
 # Weighted Poisson example (weights are totally made up)
-gm17 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson(),
-           wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
-test_show(gm17)
-@test df(gm17) == 5
-@test_approx_eq deviance(gm17) 17.699857821414266
-@test_approx_eq loglikelihood(gm17) -84.57429468506352
-@test_approx_eq aic(gm17) 179.14858937012704
-@test_approx_eq aicc(gm17) 181.39578038136298
-@test_approx_eq bic(gm17) 186.5854647596431
-@test_approx_eq coef(gm17) [3.1218557035404793,  -0.5270435906931427,-0.40300384148562746,
-                           -0.017850203824417415,-0.03507851122782909]
+@testset "Poisson LogLink Weights" begin
+    gm17 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson(),
+        wts = [1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
+    test_show(gm17)
+    @test df(gm17) == 5
+    @test isapprox(deviance(gm17), 17.699857821414266)
+    @test isapprox(loglikelihood(gm17), -84.57429468506352)
+    @test isapprox(aic(gm17), 179.14858937012704)
+    @test isapprox(aicc(gm17), 181.39578038136298)
+    @test isapprox(bic(gm17), 186.5854647596431)
+    @test isapprox(coef(gm17), [3.1218557035404793, -0.5270435906931427,-0.40300384148562746,
+                           -0.017850203824417415,-0.03507851122782909])
+end
 
-## Fitting GLMs with sparse matrices
-srand(1)
-X = sprand(1000, 10, 0.01)
-β = randn(10)
-y = Bool[rand() < logistic(x) for x in X * β]
+@testset "Sparse GLM" begin
+    srand(1)
+    X = sprand(1000, 10, 0.01)
+    β = randn(10)
+    y = Bool[rand() < logistic(x) for x in X * β]
+    gmsparse = fit(GeneralizedLinearModel, X, y, Binomial())
+    gmdense = fit(GeneralizedLinearModel, full(X), y, Binomial())
 
-gmsparse = fit(GeneralizedLinearModel, X, y, Binomial())
-gmdense = fit(GeneralizedLinearModel, full(X), y, Binomial())
+    @test isapprox(deviance(gmsparse), deviance(gmdense))
+    @test isapprox(coef(gmsparse), coef(gmdense))
+    @test isapprox(vcov(gmsparse), vcov(gmdense))
+end
 
-@test_approx_eq deviance(gmsparse) deviance(gmdense)
-@test_approx_eq coef(gmsparse) coef(gmdense)
-@test_approx_eq vcov(gmsparse) vcov(gmdense)
 
-## Prediction for GLMs
-srand(1)
-X = rand(10, 2)
-Y = Vector{Float64}(logistic.(X * [3; -3])) # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
+@testset "Predict" begin
+    srand(1)
+    X = rand(10, 2)
+    Y = logistic.(X * [3; -3])
 
-gm11 = fit(GeneralizedLinearModel, X, Y, Binomial())
-@test_approx_eq predict(gm11) Y
+    gm11 = fit(GeneralizedLinearModel, X, Y, Binomial())
+    @test isapprox(predict(gm11), Y)
 
-newX = rand(5, 2)
-newY = Vector{Float64}(logistic.(newX * coef(gm11))) # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
-@test_approx_eq predict(gm11, newX) newY
+    newX = rand(5, 2)
+    newY = logistic.(newX * coef(gm11))
+    @test isapprox(predict(gm11, newX), newY)
 
-off = rand(10)
-newoff = rand(5)
+    off = rand(10)
+    newoff = rand(5)
 
-@test_throws ArgumentError predict(gm11, newX, offset=newoff)
+    @test_throws ArgumentError predict(gm11, newX, offset=newoff)
 
-gm12 = fit(GeneralizedLinearModel, X, Y, Binomial(), offset=off)
-@test_throws ArgumentError predict(gm12, newX)
-@test_approx_eq predict(gm12, newX, offset=newoff) logistic.(newX * coef(gm12) .+ newoff)
+    gm12 = fit(GeneralizedLinearModel, X, Y, Binomial(), offset=off)
+    @test_throws ArgumentError predict(gm12, newX)
+    @test isapprox(predict(gm12, newX, offset=newoff),
+        logistic.(newX * coef(gm12) .+ newoff))
 
-## Prediction from DataFrames
-d = convert(DataFrame, X)
-d[:y] = Y
+        # Prediction from DataFrames
+    d = convert(DataFrame, X)
+    d[:y] = Y
 
-gm13 = fit(GeneralizedLinearModel, y ~ 0 + x1 + x2, d, Binomial())
-@test predict(gm13) == predict(gm13, d[[:x1, :x2]])
-@test predict(gm13) == predict(gm13, d)
+    gm13 = fit(GeneralizedLinearModel, y ~ 0 + x1 + x2, d, Binomial())
+    @test predict(gm13) == predict(gm13, d[[:x1, :x2]])
+    @test predict(gm13) == predict(gm13, d)
 
-newd = convert(DataFrame, newX)
-predict(gm13, newd)
+    newd = convert(DataFrame, newX)
+    predict(gm13, newd)
+end
 
-# Issue 118
-@inferred nobs(lm(randn(10, 2), randn(10)))
+@testset "Issue 118" begin
+    @inferred nobs(lm(randn(10, 2), randn(10)))
+end
 
-# Issue 84
-let
-    X=[1 1; 2 4; 3 9]
-    Xf=[1 1; 2 4; 3 9.]
+@testset "Issue 84" begin
+    X = [1 1; 2 4; 3 9]
+    Xf = [1 1; 2 4; 3 9.]
     y = [2, 6, 12]
     yf = [2, 6, 12.]
-    @test_approx_eq(lm(X, y).pp.beta0, ones(2))
-    @test_approx_eq(lm(Xf, y).pp.beta0, ones(2))
-    @test_approx_eq(lm(X, yf).pp.beta0, ones(2))
+    @test isapprox(lm(X, y).pp.beta0, ones(2))
+    @test isapprox(lm(Xf, y).pp.beta0, ones(2))
+    @test isapprox(lm(X, yf).pp.beta0, ones(2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,12 +214,14 @@ admit_agr2 = DataFrame(Any[[61., 151, 121, 67], [33., 54, 28, 12], pool([1, 2, 3
     [:count, :admit, :rank])
 admit_agr2[:p] = admit_agr2[:admit] ./ admit_agr2[:count]
 
+## The model matrix here is singular so tests like the deviance are just round off error
 @testset "Binomial LogitLink aggregated" begin
     gm15 = fit(GeneralizedLinearModel, p ~ rank, admit_agr2, Binomial(), wts=admit_agr2[:count])
     test_show(gm15)
     @test df(gm15) == 4
     @test nobs(gm15) == 400
-    @test isapprox(deviance(gm15), -2.4424906541753456e-15, rtol = 1e-7)
+# The model matrix is singular so the deviance is essentially round-off error
+#    @test isapprox(deviance(gm15), -2.4424906541753456e-15, rtol = 1e-7)
     @test isapprox(loglikelihood(gm15), -9.50254433604239)
     @test isapprox(aic(gm15), 27.00508867208478)
     @test isapprox(aicc(gm15), 27.106354494869592)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,8 +105,8 @@ gm7 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia, Normal(), Lo
 test_show(gm7)
 @test_approx_eq deviance(gm7) 3265.207242977156
 @test_approx_eq coef(gm7) [3.992326787835955,-0.994452693131178,-0.050698258703974,0.051494029957641]
-@test_approx_eq GLM.dispersion(gm7.model, true) 48.01787789178518
-@test_approx_eq stderr(gm7) [0.157167944259695,0.001886285986164,0.022584069426311,0.023882826190166]
+@test_approx_eq GLM.dispersion(gm7.model, true) 48.017753573192266
+@test_approx_eq_eps stderr(gm7) [0.15716774,0.0018862835,0.02258404,0.023882795] 1e-6
 
 ## Gamma example from McCullagh & Nelder (1989, pp. 300-2)
 clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
@@ -120,8 +120,8 @@ test_show(gm8)
 @test_approx_eq aicc(gm8) 42.78992394955449
 @test_approx_eq bic(gm8) 38.58159768156315
 @test_approx_eq coef(gm8) [-0.01655438172784895,0.01534311491072141]
-@test_approx_eq GLM.dispersion(gm8.model, true) 0.002446059333495581
-@test_approx_eq stderr(gm8) [0.0009275466067257,0.0004149596425600]
+@test_approx_eq_eps GLM.dispersion(gm8.model, true) 0.002446059333495581 1e-6
+@test_approx_eq_eps stderr(gm8) [0.00092754223,0.000414957683] 1e-6
 
 gm9 = fit(GeneralizedLinearModel, lot1 ~ u, clotting, Gamma(), LogLink(), convTol=1e-8)
 test_show(gm9)
@@ -144,9 +144,8 @@ test_show(gm10)
 @test_approx_eq aicc(gm10) 75.23214487456835
 @test_approx_eq bic(gm10) 71.02381860657701
 @test_approx_eq coef(gm10) [99.250446880986,-18.374324929002]
-@test_approx_eq GLM.dispersion(gm10.model, true) 0.1041772704067886
-@test_approx_eq stderr(gm10) [17.864388462865,4.297968703823]
-
+@test_approx_eq_eps GLM.dispersion(gm10.model, true) 0.10417373 1e-6
+@test_approx_eq_eps stderr(gm10) [17.864084,4.297895] 1e-4
 # Logistic regression using aggregated data and weights
 admit_agr = DataFrame(count=[28, 97, 93, 55, 33, 54, 28, 12],
                       admit=repeat([false, true], inner=[4]),


### PR DESCRIPTION
- Define methods for `updateμ!` specific to Distribution/Link combinations for the canonical link.
- Having specific methods removes some of the numerical issues in evaluating the working weights.
- Remove the unused parameter `wt` in `devresid` methods.  All calls to these methods were with `wt = 1` and it was used as a multiplier.
- Allow for multithreaded evaluation of `updateμ!` with canonical links.
- Switch tests to use `@testset` and replace calls to `@test_approx_eq a b` to `@test isapprox(a,b)`, allowing for more flexibility in setting `atol` or `rtol`