### PR TITLE
Update df to dof to accomodate StatsBase change

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 Distributions 0.10.0
-StatsBase 0.8.3
+StatsBase 0.11.0
 StatsFuns 0.3.0
 Reexport

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -11,9 +11,9 @@ module GLM
     using Distributions: sqrt2, sqrt2π
 
     import Base: (\), cholfact, convert, cor, show, size
-    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, r2, r², adjr2, adjr²
+    import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, r2, r², adjr2, adjr²
     import StatsFuns: xlogy
-    export coef, coeftable, confint, deviance, nulldeviance, df, df_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, r2, r², adjr2, adjr²
+    export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, r2, r², adjr2, adjr²
 
     export                              # types
         CauchitLink,

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -191,7 +191,7 @@ function loglikelihood(m::AbstractGLM)
     ll
 end
 
-df(x::GeneralizedLinearModel) = dispersion_parameter(x.rr.d) ? length(coef(x)) + 1 : length(coef(x))
+dof(x::GeneralizedLinearModel) = dispersion_parameter(x.rr.d) ? length(coef(x)) + 1 : length(coef(x))
 
 function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real,
               convTol::Real, start)
@@ -339,7 +339,7 @@ function dispersion(m::AbstractGLM, sqr::Bool=false)
     r = m.rr
     if dispersion_parameter(r.d)
         wrkwt, wrkresid = r.wrkwt, r.wrkresid
-        s = sum(i -> wrkwt[i] * abs2(wrkresid[i]), eachindex(wrkwt, wrkresid)) / df_residual(m)
+        s = sum(i -> wrkwt[i] * abs2(wrkresid[i]), eachindex(wrkwt, wrkresid)) / dof_residual(m)
         sqr ? s : sqrt(s)
     else
         one(eltype(r.mu))

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -165,4 +165,4 @@ end
 coef(x::LinPred) = x.beta0
 coef(obj::LinPredModel) = coef(obj.pp)
 
-df_residual(obj::LinPredModel) = nobs(obj) - length(coef(obj))
+dof_residual(obj::LinPredModel) = nobs(obj) - length(coef(obj))

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -118,7 +118,7 @@ lm(X, y) = fit(LinearModel, X, y)
 lmc(X, y) = fit(LinearModel{DensePredChol}, X, y)
 
 
-df(x::LinearModel) = length(coef(x)) + 1
+dof(x::LinearModel) = length(coef(x)) + 1
 
 """
     deviance(obj::LinearModel)
@@ -140,13 +140,13 @@ r2(obj::LinearModel) = 1 - deviance(obj)/nulldeviance(obj)
 
 function adjr2(obj::LinearModel)
     n = nobs(obj)
-    # df() includes the dispersion parameter
-    p = df(obj) - 1
+    # dof() includes the dispersion parameter
+    p = dof(obj) - 1
     1 - (1 - r²(obj))*(n-1)/(n-p)
 end
 
 function dispersion(x::LinearModel, sqr::Bool=false)
-    ssqr = deviance(x.rr)/df_residual(x)
+    ssqr = deviance(x.rr)/dof_residual(x)
     return sqr ? ssqr : sqrt(ssqr)
 end
 
@@ -154,7 +154,7 @@ function coeftable(mm::LinearModel)
     cc = coef(mm)
     se = stderr(mm)
     tt = cc ./ se
-    CoefTable(hcat(cc,se,tt,ccdf(FDist(1, df_residual(mm)), abs2.(tt))),
+    CoefTable(hcat(cc,se,tt,ccdf(FDist(1, dof_residual(mm)), abs2.(tt))),
               ["Estimate","Std.Error","t value", "Pr(>|t|)"],
               ["x$i" for i = 1:size(mm.pp.X, 2)], 4)
 end
@@ -163,6 +163,6 @@ predict(mm::LinearModel, newx::Matrix) =  newx * coef(mm)
 
 function confint(obj::LinearModel, level::Real)
     hcat(coef(obj),coef(obj)) + stderr(obj) *
-    quantile(TDist(df_residual(obj)), (1. - level)/2.) * [1. -1.]
+    quantile(TDist(dof_residual(obj)), (1. - level)/2.) * [1. -1.]
 end
 confint(obj::LinearModel) = confint(obj, 0.95)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-DataFrames 0.8.0
+DataFrames 0.8.4
 StatsFuns 0.3.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ form = DataFrame(Any[[0.1,0.3,0.5,0.6,0.7,0.9],[0.086,0.269,0.446,0.538,0.626,0.
         -9.464489795918525e-05 1.831836734693908e-04]
     @test isapprox(vcov(lm1), Σ)
     @test isapprox(cor(lm1.model), diagm(diag(Σ))^(-1/2)*Σ*diagm(diag(Σ))^(-1/2))
-    @test df(lm1) == 3
+    @test dof(lm1) == 3
     @test isapprox(deviance(lm1), 0.0002992000000000012)
     @test isapprox(loglikelihood(lm1), 21.204842144047973)
     @test isapprox(nulldeviance(lm1), 0.3138488333333334)
@@ -40,7 +40,7 @@ dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
 @testset "Poisson GLM" begin
     gm1 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson())
     test_show(gm1)
-    @test df(gm1) == 5
+    @test dof(gm1) == 5
     @test isapprox(deviance(gm1), 5.12914107700115, rtol = 1e-7)
     @test isapprox(loglikelihood(gm1), -23.380659200978837, rtol = 1e-7)
     @test isapprox(aic(gm1), 56.76131840195767)
@@ -58,7 +58,7 @@ admit[:rank] = pool(admit[:rank])
     for distr in (Binomial, Bernoulli)
         gm2 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit, distr())
         test_show(gm2)
-        @test df(gm2) == 6
+        @test dof(gm2) == 6
         @test isapprox(deviance(gm2), 458.5174924758994)
         @test isapprox(loglikelihood(gm2), -229.25874623794968)
         @test isapprox(aic(gm2), 470.51749247589936)
@@ -74,7 +74,7 @@ end
     gm3 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
         Binomial(), ProbitLink())
     test_show(gm3)
-    @test df(gm3) == 6
+    @test dof(gm3) == 6
     @test isapprox(deviance(gm3), 458.4131713833386)
     @test isapprox(loglikelihood(gm3), -229.20658569166932)
     @test isapprox(aic(gm3), 470.41317138333864)
@@ -89,7 +89,7 @@ end
     gm4 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
         Binomial(), CauchitLink())
     test_show(gm4)
-    @test df(gm4) == 6
+    @test dof(gm4) == 6
     @test isapprox(deviance(gm4), 459.3401112751141)
     @test isapprox(loglikelihood(gm4), -229.6700556375571)
     @test isapprox(aic(gm4), 471.3401112751142)
@@ -101,7 +101,7 @@ end
     gm5 = fit(GeneralizedLinearModel, admit ~ gre + gpa + rank, admit,
         Binomial(), CloglogLink())
     test_show(gm5)
-    @test df(gm5) == 6
+    @test dof(gm5) == 6
     @test isapprox(deviance(gm5), 458.89439629612616)
     @test isapprox(loglikelihood(gm5), -229.44719814806314)
     @test isapprox(aic(gm5), 470.8943962961263)
@@ -117,7 +117,7 @@ anorexia[:Treat] = pool(anorexia[:Treat])
     gm6 = fit(GeneralizedLinearModel, Postwt ~ Prewt + Treat, anorexia,
         Normal(), IdentityLink(), offset=Array(anorexia[:Prewt]))
     test_show(gm6)
-    @test df(gm6) == 5
+    @test dof(gm6) == 5
     @test isapprox(deviance(gm6), 3311.262619919613)
     @test isapprox(loglikelihood(gm6), -239.9866487711122)
     @test isapprox(aic(gm6), 489.9732975422244)
@@ -148,7 +148,7 @@ clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
 @testset "Gamma InverseLink" begin
     gm8 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma())
     test_show(gm8)
-    @test df(gm8) == 3
+    @test dof(gm8) == 3
     @test isapprox(deviance(gm8), 0.016729715178484157)
     @test isapprox(loglikelihood(gm8), -15.994961974777247)
     @test isapprox(aic(gm8), 37.989923949554495)
@@ -163,7 +163,7 @@ end
     gm9 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(), LogLink(),
         convTol=1e-8)
     test_show(gm9)
-    @test df(gm9) == 3
+    @test dof(gm9) == 3
     @test isapprox(deviance(gm9), 0.16260829451739)
     @test isapprox(loglikelihood(gm9), -26.24082810384911)
     @test isapprox(aic(gm9), 58.48165620769822)
@@ -178,7 +178,7 @@ end
     gm10 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(), IdentityLink(),
         convTol=1e-8)
     test_show(gm10)
-    @test df(gm10) == 3
+    @test dof(gm10) == 3
     @test isapprox(deviance(gm10), 0.60845414895344)
     @test isapprox(loglikelihood(gm10), -32.216072437284176)
     @test isapprox(aic(gm10), 70.43214487456835)
@@ -197,7 +197,7 @@ admit_agr = DataFrame(count = [28., 97, 93, 55, 33, 54, 28, 12],
 @testset "Aggregated Binomial LogitLink" begin
     for distr in (Binomial, Bernoulli)
         gm14 = fit(GeneralizedLinearModel, admit ~ rank, admit_agr, distr(), wts=Array(admit_agr[:count]))
-        @test df(gm14) == 4
+        @test dof(gm14) == 4
         @test nobs(gm14) == 400
         @test isapprox(deviance(gm14), 474.9667184280627)
         @test isapprox(loglikelihood(gm14), -237.48335921403134)
@@ -218,7 +218,7 @@ admit_agr2[:p] = admit_agr2[:admit] ./ admit_agr2[:count]
 @testset "Binomial LogitLink aggregated" begin
     gm15 = fit(GeneralizedLinearModel, p ~ rank, admit_agr2, Binomial(), wts=admit_agr2[:count])
     test_show(gm15)
-    @test df(gm15) == 4
+    @test dof(gm15) == 4
     @test nobs(gm15) == 400
 # The model matrix is singular so the deviance is essentially round-off error
 #    @test isapprox(deviance(gm15), -2.4424906541753456e-15, rtol = 1e-7)
@@ -235,7 +235,7 @@ end
     gm16 = fit(GeneralizedLinearModel, lot1 ~ 1 + u, clotting, Gamma(),
         wts=[1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
     test_show(gm16)
-    @test df(gm16) == 3
+    @test dof(gm16) == 3
     @test nobs(gm16) == 32.7
     @test isapprox(deviance(gm16), 0.03933389380881689)
     @test isapprox(loglikelihood(gm16), -43.35907878769152)
@@ -250,7 +250,7 @@ end
     gm17 = fit(GeneralizedLinearModel, Counts ~ Outcome + Treatment, dobson, Poisson(),
         wts = [1.5,2.0,1.1,4.5,2.4,3.5,5.6,5.4,6.7])
     test_show(gm17)
-    @test df(gm17) == 5
+    @test dof(gm17) == 5
     @test isapprox(deviance(gm17), 17.699857821414266)
     @test isapprox(loglikelihood(gm17), -84.57429468506352)
     @test isapprox(aic(gm17), 179.14858937012704)


### PR DESCRIPTION
This bumps the StatsBase requirement to 0.11.0, which deprecates `df` in favor of `dof`, and changes all occurrences of `df` to `dof` to accomodate that change.