### PR TITLE
Eliminate memory allocation for weights adjustments

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -56,7 +56,7 @@ function updateμ!{T<:FPVector,D,L}(r::GlmResp{T,D,L}, linPr::T)
     updateμ!(r)
     if !isempty(r.wts)
         map!(*, r.devresid, r.devresid, r.wts)
-	map!(*, r.wrkwt, r.wrkwt, r.wts)
+        map!(*, r.wrkwt, r.wrkwt, r.wts)
     end
     r
 end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -46,19 +46,6 @@ end
 deviance(r::GlmResp) = sum(r.devresid)
 
 """
-    wtscale!{T<:FPVector}(devr::T, wkwt::T, wt::T)
-
-Scale the deviance residuals, `devr`, and the working weights, `wkwt`, by `wt`,
-when `wt` is nonempty.
-"""
-function wtscale!{T<:FPVector}(devr::T, wkwt::T, wt::T)
-    if !isempty(wt)
-        devr .*= wt
-        wkwt .*= wt
-    end
-end
-
-"""
     updateμ!{T<:FPVector}(r::GlmResp{T}, linPr::T)
 
 Update the mean, working weights and working residuals, in `r` given a value of
@@ -68,8 +55,8 @@ function updateμ!{T<:FPVector,D,L}(r::GlmResp{T,D,L}, linPr::T)
     isempty(r.offset) ? copy!(r.eta, linPr) : broadcast!(+, r.eta, linPr, r.offset)
     updateμ!(r)
     if !isempty(r.wts)
-        r.devresid .*= r.wts
-        r.wrkwt .*= r.wts
+        map!(*, r.devresid, r.devresid, r.wts)
+	map!(*, r.wrkwt, r.wrkwt, r.wts)
     end
     r
 end


### PR DESCRIPTION
Using memory profiling I found that memory was being allocated in a convenience function that was called in only one place.