### PR TITLE
Make linear model easier to extend to new array types.

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -46,8 +46,7 @@ module GLM
         linkinv,        # inverse link mapping eta to mu
         linpred,        # linear predictor
         linpred!,       # update the linear predictor
-        lm,             # linear model (QR factorization)
-        lmc,            # linear model (Cholesky factorization)
+        lm,             # linear model
         mueta,          # derivative of inverse link
         mustart,        # derive starting values for the mu vector
         nobs,           # total number of observations
@@ -56,7 +55,7 @@ module GLM
         wrkresp         # working response
 
     typealias FP AbstractFloat
-    typealias FPVector{T<:FP} DenseArray{T,1}
+    typealias FPVector{T<:FP} AbstractArray{T,1}
 
     abstract ModResp                   # model response
 

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -44,14 +44,18 @@ type DensePredChol{T<:BlasReal,C} <: DensePred
     chol::C
     scratch::Matrix{T}
 end
-DensePredChol{T<:BlasReal}(X::Matrix{T}) =
-    DensePredChol(X,
+function DensePredChol(X::StridedMatrix)
+    F = cholfact!(float(X'X))
+    T = eltype(F)
+    DensePredChol(AbstractMatrix{T}(X),
         zeros(T, size(X, 2)),
         zeros(T, size(X, 2)),
         zeros(T, size(X, 2)),
-        cholfact!(X'X),
-        similar(X))
-cholpred(X::Matrix) = DensePredChol(X)
+        F,
+        similar(X, T))
+end
+
+cholpred(X::StridedMatrix) = DensePredChol(X)
 
 cholfactors(c::Cholesky) = c.factors
 Base.LinAlg.cholfact!{T<:FP}(p::DensePredChol{T}) = p.chol
@@ -107,6 +111,7 @@ function SparsePredChol{T}(X::SparseMatrixCSC{T})
         chol,
         similar(X))
 end
+
 cholpred(X::SparseMatrixCSC) = SparsePredChol(X)
 
 function delbeta!{T}(p::SparsePredChol{T}, r::Vector{T}, wt::Vector{T})


### PR DESCRIPTION
Introduce `fit!` and create `LinearModel` instance before fitting of the linear model.

Use Cholesky by default.

These changes are motivated by an attempt to extend `GLM.jl` to other array types and they shouldn't have an impact on normal usage of the package.

I think it was cumbersome to construct the correct `LmResp` and `LinPred` data types without constructing the instances which the old version of `fit` required. Here I instead instantiate the types, create the `LinearModel` and call `fit!`.

The change to using Cholesky is not strictly necessary but I think that a Cholesky is implemented slightly more than the QR for other matrix types. It is also much faster to use Cholesky and my view is that the error due to numerical precision loss are insignificant relative to the statistical error, i.e. if `X'X` is so badly conditioned that using the QR actually matters, then the variance of the estimates is enormous.