### PR TITLE
Stop Travis testing on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
     - linux
-    - osx
 julia:
     - 0.5
     - nightly


### PR DESCRIPTION
It is unlikely that anything in the package would fail on OS X only and the OS X queue is always long