### PR TITLE
confidence intervals in predict()

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ julia> predict(OLS)
  4.33333
  6.83333
 
+# Prediction with new data and confidence values
+ julia> newX = DataFrame(X=[2,3,4]);
+ julia> predict(OLS, newX, :confint)
+ 3×3 Array{Float64,2}:
+  4.33333  1.33845   7.32821
+  6.83333  2.09801  11.5687
+  9.33333  1.40962  17.257  
+# The columns of the matrix are prediction, lower and upper confidence interval
+
 ```
 
 Probit Regression:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ julia> predict(OLS)
   4.33333  1.33845   7.32821
   6.83333  2.09801  11.5687
   9.33333  1.40962  17.257  
-# The columns of the matrix are prediction, lower and upper confidence interval
+# The columns of the matrix are prediction, 95% lower and upper confidence bounds
 
 ```
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -158,7 +158,7 @@ end
 
 predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
-function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
+function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol; level = 0.95, alpha = 1 - level)
     retmean = newx * coef(mm)
     interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
 
@@ -166,7 +166,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, l
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     retvariance = (newx/R).^2 * residvar
 
-    interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt.(retvariance)
+    interval = quantile(TDist(dof_residual(mm)), alpha/2) * sqrt.(retvariance)
     retmean, retmean .+ interval, retmean .- interval
 end
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -160,15 +160,15 @@ end
 getR(x::DensePredChol) = UpperTriangular(x.chol.factors)
 getR(x::DensePredQR) = x.qr[:R]
 
-function predict(mm::LinearModel, newx::Matrix; error::Symbol = :none)
+function predict(mm::LinearModel, newx::Matrix; error::Symbol = :none, level = 0.95)
     prediction = newx * coef(mm)
     error == :none && return prediction
     error == :confint || error("specify error as :none or :confint") #:predint will be implemented
-    R = getR(mod.model.pp)
+    R = getR(mm.pp)
 
     tmp = newx * (R\Diagonal(ones(3,3)))
-    tmp = tmp.^2 * (ones(3,1) * deviance(mod)/dof_residual(mod))
-    tval = quantile(TDist(dof_residual(mod)), 0.025)
+    tmp = tmp.^2 * (ones(3,1) * deviance(mm)/dof_residual(mm))
+    tval = quantile(TDist(dof_residual(mm)), 1. -level/2)
     interval = tval * sqrt(tmp)
 
     hcat(prediction, prediction + interval, prediction - interval)

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -159,18 +159,14 @@ end
 predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
 """
-For linear models, specifying `interval_type` will return a 3-tuple with the
-predicted values, the lower and the higher confidence bound. Confidence intervals
-delimit the uncertainty of the estimate of the predicted values, prediction
-intervals delimit the estimated bounds for any new data points from the
-population.
-
-# Arguments
-* `interval_type::Symbol`: one of `:confint` or `:predint`
-* `level=0.95`: the level of the confidence interval
-* `alpha=1-level`: an alternative way of specifying the level of the interval
+    predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
+    
+Specifying `interval_type` will return a 3-column matrix with the prediction and
+the low and high confidence bounds for a given `level` (0.95 equates alpha = 0.05).
+Valid values of `interval_type` are `:confint` delimiting the  uncertainty of the
+predicted relationship, and `:predint` delimiting estimated bounds for new data points.
 """
-function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol; level = 0.95, alpha = 1 - level)
+function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
     retmean = newx * coef(mm)
     interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
 
@@ -178,8 +174,8 @@ function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol; l
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     retvariance = (newx/R).^2 * residvar
 
-    interval = quantile(TDist(dof_residual(mm)), alpha/2) * sqrt.(retvariance)
-    retmean, retmean .+ interval, retmean .- interval
+    interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt.(retvariance)
+    hcat(retmean, retmean .+ interval, retmean .- interval)
 end
 
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -166,7 +166,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, l
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     retvariance = (newx/R).^2 * residvar
 
-    interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt(retvariance)
+    interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt.(retvariance)
     retmean, retmean .+ interval, retmean .- interval
 end
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -169,6 +169,7 @@ predicted relationship, and `:predint` delimiting estimated bounds for new data 
 function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level::Real = 0.95)
     retmean = newx * coef(mm)
     interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
+    length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
 
     R = cholfact!(mm.pp)[:U] #get the R matrix from the QR factorization
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -159,14 +159,14 @@ end
 predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
 """
-    predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
-    
+    predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level::Real = 0.95)
+
 Specifying `interval_type` will return a 3-column matrix with the prediction and
-the low and high confidence bounds for a given `level` (0.95 equates alpha = 0.05).
+the lower and upper confidence bounds for a given `level` (0.95 equates alpha = 0.05).
 Valid values of `interval_type` are `:confint` delimiting the  uncertainty of the
 predicted relationship, and `:predint` delimiting estimated bounds for new data points.
 """
-function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
+function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level::Real = 0.95)
     retmean = newx * coef(mm)
     interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -160,10 +160,11 @@ end
 getR(x::DensePredChol) = UpperTriangular(x.chol.factors)
 getR(x::DensePredQR) = x.qr[:R]
 
-function predict(mm::LinearModel, newx::Matrix; error::Symbol = :none, level = 0.95)
+predict((::LinearModel, newx::Matrix)) = newx * coef(mm)
+
+function predict(mm::LinearModel, newx::Matrix, interval_type::Symbol, level = 0.95)
     prediction = newx * coef(mm)
-    error == :none && return prediction
-    error == :confint || error("specify error as :none or :confint") #:predint will be implemented
+    interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
     R = getR(mm.pp)
 
     tmp = newx * (R\Diagonal(ones(3,3)))

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -162,12 +162,10 @@ predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
 function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, level = 0.95)
     prediction = newx * coef(mm)
-    #interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
+    interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented
 
     R = cholfact!(mm.pp)[:U] #get the R matrix from the QR factorization
-    # get the multipliers for the final interval
     residvar = (ones(3,1) * deviance(mm)/dof_residual(mm))'
-    tval = quantile(TDist(dof_residual(mm)), (1 - level)/2)
 
     function _local(x::StridedVector)
         Ac_ldiv_B!(R,x)
@@ -179,7 +177,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, l
         interval[i] = _local(newx[i,:])[1]
     end
 
-    interval = tval * sqrt(interval)
+    interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt(interval)
     prediction, prediction .+ interval, prediction .- interval
 end
 

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -160,7 +160,7 @@ predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
 """
 For linear models, specifying `interval_type` will return a 3-tuple with the
-predicted values, the upper and the lower confidence bound. Confidence intervals
+predicted values, the lower and the higher confidence bound. Confidence intervals
 delimit the uncertainty of the estimate of the predicted values, prediction
 intervals delimit the estimated bounds for any new data points from the
 population.

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -158,6 +158,18 @@ end
 
 predict(mm::LinearModel, newx::AbstractMatrix) = newx * coef(mm)
 
+"""
+For linear models, specifying `interval_type` will return a 3-tuple with the
+predicted values, the upper and the lower confidence bound. Confidence intervals
+delimit the uncertainty of the estimate of the predicted values, prediction
+intervals delimit the estimated bounds for any new data points from the
+population.
+
+# Arguments
+* `interval_type::Symbol`: one of `:confint` or `:predint`
+* `level=0.95`: the level of the confidence interval
+* `alpha=1-level`: an alternative way of specifying the level of the interval
+"""
 function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol; level = 0.95, alpha = 1 - level)
     retmean = newx * coef(mm)
     interval_type == :confint || error("only :confint is currently implemented") #:predint will be implemented

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,6 +306,12 @@ end
 
     newd = convert(DataFrame, newX)
     predict(gm13, newd)
+
+    Ylm = X * [0.8, 1.6] + 0.8randn(10)
+    mm = fit(LinearModel, X, Ylm)
+    pm, lo, hi = predict(mm, newX, :confint)
+    @test isapprox(lo[5], 0.8543142404183606)
+    @test isapprox(hi[2], 1.2766396685055916)
 end
 
 @testset "Issue 118" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,9 +309,19 @@ end
 
     Ylm = X * [0.8, 1.6] + 0.8randn(10)
     mm = fit(LinearModel, X, Ylm)
-    pm, lo, hi = predict(mm, newX, :confint)
-    @test isapprox(lo[5], 0.8543142404183606)
-    @test isapprox(hi[2], 1.2766396685055916)
+    pred = predict(mm, newX, :confint)
+
+    @test isapprox(pred[1,2], 0.6122189104014528)
+    @test isapprox(pred[2,2], -0.33530477814532056)
+    @test isapprox(pred[3,2], 1.340413688904295)
+    @test isapprox(pred[4,2], 0.02118806218116165)
+    @test isapprox(pred[5,2], 0.8543142404183606)
+    @test isapprox(pred[1,3], 2.6853964084909836)
+    @test isapprox(pred[2,3], 1.2766396685055916)
+    @test isapprox(pred[3,3], 3.6617479283005894)
+    @test isapprox(pred[4,3], 0.6477623101170038)
+    @test isapprox(pred[5,3], 2.564532433982956)
+    
 end
 
 @testset "Issue 118" begin


### PR DESCRIPTION
Adds basic support for confidence intervals in predict() (see https://github.com/JuliaStats/GLM.jl/issues/101)

I have so far only added to the `lm()` function, but it should be fairly easy to transfor to the `glm()` method. Also, the `predict` call is through `DataFrames`, but I have not touched that package, so it only works inside the module (I use Atom’s ability to set the working module). Also, it is not extensively tested. Oh, and because the intervals return a `Matrix`, this makes the `predict` function not be type stable, so some thought is needed here.
But it is something to build upon.

A quick example (notice I have to jump through some hoops because I bypass DataFrames):
```julia
using DataFrames, RCall
a = randn(100); b = randn(100); c = a .+ b .+ 0.8randn(100);
df = DataFrame(a = a, b = b, c = c);
mod = lm(c ~ a + b, df)

predict(LinearModel(mod.model), hcat(ones(100),Matrix(df[:,1:2])), :confint)
R"""
mod <- lm(c ~ a + b, $(df))
predict(mod, interval = "confidence")
"""
```