### PR TITLE
Uses ConvergenceException

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 Distributions 0.10.0
-StatsBase 0.11.0
+StatsBase 0.12.0
 StatsFuns 0.3.0
 Reexport

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -239,7 +239,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
         end
         devold = dev
     end
-    cvg || error("failure to converge in $maxIter iterations")
+		cvg || throw(ConvergenceException(maxIter))
     m.fit = true
     m
 end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -239,7 +239,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
         end
         devold = dev
     end
-		cvg || throw(ConvergenceException(maxIter))
+    cvg || throw(ConvergenceException(maxIter))
     m.fit = true
     m
 end


### PR DESCRIPTION
This PR uses the newly added ConvergenceException in StatsBase to indicate to the user that a fit operation failed to converge.