### PR TITLE
Doc and README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # Linear models (lm's) and generalized linear models (glm's) in Julia
 
 [![Travis](https://travis-ci.org/JuliaStats/GLM.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/GLM.jl)
-[![GLM](http://pkg.julialang.org/badges/GLM_0.4.svg)](http://pkg.julialang.org/?pkg=GLM)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaStats/GLM.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaStats/GLM.jl?branch=master)
 [![GLM](http://pkg.julialang.org/badges/GLM_0.5.svg)](http://pkg.julialang.org/?pkg=GLM)
-
-## Older versions
-
-This documentation applies to the current version of GLM.jl, which requires Julia 0.5 or later.
-You may also be interested in the documentation for [GLM.jl 0.2.5](https://github.com/JuliaStats/GLM.jl/tree/v0.2.5), the last release for Julia 0.2, or [GLM.jl 0.4.8](https://github.com/JuliaStats/GLM.jl/tree/v0.4.8), the last release for Julia 0.3.
+[![GLM](http://pkg.julialang.org/badges/GLM_0.6.svg)](http://pkg.julialang.org/?pkg=GLM)
 
 ## Installation
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -105,23 +105,10 @@ Constructors
 Extractors
 ----------
 
-These extractors are defined for ``m`` of type
-:type:`LinPredModel`.
-
-.. function:: coef(m) -> Vector{Float64}
-
-   Coefficient estimates
-
-.. function:: coeftable(m) -> DataFrame
-
-   A dataframe with the current fixed-effects parameter vector, the
-   standard errors, their ratio and the p-value for the ratio.
-
-.. function:: confint(m[, level]) -> Matrix{Float64}
-
-   A matrix of the lower and upper end-points of the (marginal)
-   confidence intervals on the coefficients.  The confidence level,
-   ``level``, defaults to 0.95.
+These extractors are defined for ``m`` of type :type:`LinPredModel`. Other
+extractors from the StatsBase package and applicable to any ``StatisticalModel``
+object can also be used.
+See `the StatsBase documentation <http://statsbasejl.readthedocs.io/en/latest/statmodels.html>`__.
 
 .. function:: dispersion(m, sqr=false) -> Float64
 
@@ -131,13 +118,6 @@ These extractors are defined for ``m`` of type
 
    If ``sqr`` is ``true``, the squared parameter is returned.
 
-.. function:: stderr(m) -> Vector{Float64}
-
-   Standard errors of the fixed-effects parameters
-
-.. function:: vcov(m) -> Matrix{Float64}
-
-   Estimated variance-covariance matrix of the fixed-effects parameters
 
 Indices and tables
 ==================


### PR DESCRIPTION
Remove list of extractors which are documented in StatsBase (the
docstrings where out of sync for coeftable).
Remove outdated references in README and add new badges.

----
The docs don't seem to be used anywhere so it doesn't really matter. At some point we should move all documentation from README.md to a proper Documenter manual (https://github.com/JuliaStats/GLM.jl/pull/138 is a good step toward that goal).