### PR TITLE
Clamp cloglog inverse link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -14,8 +14,12 @@ linkinv(::CauchitLink, η) = oftype(η, 0.5) + atan(η) / pi
 mueta(::CauchitLink, η) = one(η) / (pi * (one(η) + abs2(η)))
 
 linkfun(::CloglogLink, μ) = log(-log1p(-μ))
-linkinv(::CloglogLink, η) = -expm1(-exp(η))
-mueta(::CloglogLink, η) = exp(η) * exp(-exp(η))
+function linkinv(::CloglogLink, η::T) where {T<:AbstractFloat}
+    clamp(-expm1(-exp(η)), eps(T), one(T) - eps(T))
+end
+function mueta(::CloglogLink, η::T) where {T<:AbstractFloat}
+    max(eps(T), exp(η) * exp(-exp(η)))
+end
 
 linkfun(::IdentityLink, μ) = μ
 linkinv(::IdentityLink, η) = η

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -14,10 +14,10 @@ linkinv(::CauchitLink, η) = oftype(η, 0.5) + atan(η) / pi
 mueta(::CauchitLink, η) = one(η) / (pi * (one(η) + abs2(η)))
 
 linkfun(::CloglogLink, μ) = log(-log1p(-μ))
-function linkinv(::CloglogLink, η::T) where {T<:AbstractFloat}
+function linkinv{T<:AbstractFloat}(::CloglogLink, η::T) 
     clamp(-expm1(-exp(η)), eps(T), one(T) - eps(T))
 end
-function mueta(::CloglogLink, η::T) where {T<:AbstractFloat}
+function mueta{T<:AbstractFloat}(::CloglogLink, η::T)
     max(eps(T), exp(η) * exp(-exp(η)))
 end
 

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -14,10 +14,10 @@ linkinv(::CauchitLink, η) = oftype(η, 0.5) + atan(η) / pi
 mueta(::CauchitLink, η) = one(η) / (pi * (one(η) + abs2(η)))
 
 linkfun(::CloglogLink, μ) = log(-log1p(-μ))
-function linkinv{T<:AbstractFloat}(::CloglogLink, η::T) 
+function linkinv{T<:Real}(::CloglogLink, η::T)
     clamp(-expm1(-exp(η)), eps(T), one(T) - eps(T))
 end
-function mueta{T<:AbstractFloat}(::CloglogLink, η::T)
+function mueta{T<:Real}(::CloglogLink, η::T)
     max(eps(T), exp(η) * exp(-exp(η)))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,18 @@ end
     @test isapprox(aic(gm5), 470.8943962961263)
     @test isapprox(aicc(gm5), 471.1081367541415)
     @test isapprox(bic(gm5), 494.8431835787742)
+
+    # When data is almost separated, the calculations are prone to underflow which can cause
+    # NaN in wrkwt and/or wrkres. The example here used to fail but works with the "clamping"
+    # introduced in #187
+    @testset "separated data" begin
+        n   = 100
+        rng = MersenneTwister(123)
+
+        X = [ones(n) randn(rng, n)]
+        y = StatsFuns.logistic.(X*ones(2) + 1/10*randn(rng, n)) .> 1/2
+        @test coeftable(glm(X, y, Binomial(), CloglogLink())).cols[4][2].v < 0.05
+    end
 end
 
 ## Example with offsets from Venables & Ripley (2002, p.189)


### PR DESCRIPTION
See https://github.com/dmbates/MixedModels.jl/issues/92 for an example of what can happen if you don't clamp the values on the mean scale to (0,1)

If μ, the value of the inverse link applied to the linear predictor, rounds down to zero or, more commonly, rounds up to one, then the `glmvar` value is zero, resulting in a division by zero.  @andreasnoack contributed special method for `glmvar` the helps with this problem if the inverse link function is "odd" (actually f(-x) == 1 - f(x)) in this case).  In the most common case of the canonical (Logit) link, the calculation of the glmvar can be and is by-passed.  

This link doesn't have such a nice way of avoiding the numerical problems, as far as I can see.