### PR TITLE
RFC: Introduce complementary return value in linkinv

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,5 @@ julia 0.5
 Compat 0.18.0
 Distributions 0.10.0
 StatsBase 0.12.0
-StatsFuns 0.3.0
 Reexport
 SpecialFunctions 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,5 @@ Compat 0.18.0
 Distributions 0.10.0
 StatsBase 0.12.0
 Reexport
+StatsFuns 0.3.0
 SpecialFunctions 0.1.0

--- a/docs/src/links.jmd
+++ b/docs/src/links.jmd
@@ -1,0 +1,204 @@
+---
+title: Notes on link functions for GLMs
+author: Douglas Bates
+date: July 27, 2017
+---
+
+In a generalized linear model (GLM) the *n*-dimensional random variable $\mathcal{Y}$, whose observed value is $\mathbf{y}$, the *response vector*, is modeled as independent observations from a scalar distribution family $\mathcal{D}$.
+The scalar distributions differ only in their expected values.
+If there are other parameters in the scalar distribution, $\mathcal{D}$, such as a dispersion parameter, they are assumed to be equal across the observations.
+The expected value of $\mathcal{Y}$ is modeled as
+\begin{equation}
+\mathsf{𝖤}(\mathcal{Y}) = \mathbf{\mu} = \mathbf{g}^{-1}(\mathbf{X}\mathbf{β})
+\end{equation}
+where $\mathbf{\eta}=\mathbf{X\beta}$ is the *linear predictor* formed from the $n\times p$ *model matrix*, $\mathbf{X}$, and the $p$-dimensional *coefficient vector*, $\mathbf{\beta}$, and $\mathbf{g}^{-1}$ is the vector-valued *inverse link* function.
+
+The vector-valued *link* and *inverse link* functions are component-wise applications of a scalar link, $g$, and its inverse, $g^{-1}$, which map the possibly restricted range of the mean, $\mu$, to the unrestricted range of $\eta$ and vice-versa.
+For example, if 𝒟 is the [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution) then μ ∈ (0, ∞) while η ∈ (-∞, ∞) and typically a *log link*,
+\begin{equation}
+\eta = g(\mu) = \log(\mu),
+\end{equation}
+with inverse,
+\begin{equation}
+\mu = g^{-1}(\eta) = \exp(\eta),
+\end{equation}
+is used.
+
+In the linear model, which is the model generalized by the GLM, the link and its inverse are the identity function so that
+\begin{equation}
+\mathcal{Y}\sim\mathcal{N}(\mathbf \mu, \sigma^2\mathbf I).
+\end{equation}
+
+The scalar link and inverse link functions should be continuous and differentiable.
+To be invertible they must also be monotone.
+Without loss of generality we will assume they are monotone increasing.
+
+The *Iteratively Reweighted Least Squares* (IRLS) algorithm is a simple, effective method of determining the maximum likelihood estimates (mle's) of the coefficients, $\mathbf\beta$, and the dispersion parameter, $\phi$, if $\mathcal{D}$ has such a parameter.
+The iterative step, given the current $\mathbf\beta$, is to evaluate $\mathbf{\eta}=\mathbf{X\beta}$ then $\mathbf{\mu} = \mathbf{g}^{-1}(\mathbf{\eta})$ and the Jacobian $\frac{d\mathbf{\mu}}{d\mathbf{\eta}}$, which is, by definition, diagonal.
+The purpose is to determine an increment, `δ𝛃`, in the linear predictor scale from information on the residuals and the variance of the response on the response scale.
+The *working residuals*, `𝐫 = (dμ/d𝛈)⁻¹(𝐲 - 𝛍)` are the residuals `𝐲 - 𝛍` on the response scale transformed back to the linear predictor scale.
+The diagonal matrix of *working weights*, `𝐖 = (d𝛍/d𝛈)²𝒱⁻¹(𝛍)` is derived from the *variance function*, `𝒱(𝛍)`, of the distribution `𝒟`, which is the part of the variance that depends on the mean, 𝛍, only.
+The increment is the weighted least squares solution of `𝐗′𝐖𝐗 δ𝛃 = 𝐗′𝐫`.
+
+A distribution in the [exponential family](https://en.wikipedia.org/wiki/Exponential_family) has a [*canonical link*](https://en.wikipedia.org/wiki/Generalized_linear_model#Link_function) associated with it.
+One of the properties of the canonical link is that the Jacobian of the inverse link is the variance function for the distribution.
+The expression for the working weights simplifies to
+\begin{equation}
+\mathbf{W} = \frac{d\mu}{d\eta}
+\end{equation}
+
+## Simple link objects
+
+In the implementation in the [GLM package](https://github.com/JuliaStats/GLM.jl) a `Link` is an immutable object that is used to dispatch methods for the generic functions `linkfun`, `linkinv` and `mueta`.
+```{julia;label=linkdefs;term=true}
+abstract type Link end
+```
+
+For example, we define the `IdentityLink` as
+```{julia;label=IdentityLink;term=true}
+immutable IdentityLink <: Link end
+linkfun(::IdentityLink, μ) = μ
+linkinv(::IdentityLink, η) = η
+mueta(  ::IdentityLink, η) = one(η)  # returns the unit element of the same type as η
+```
+the `LogLink` as
+```{julia;label=LogLink;term=true}
+immutable LogLink <: Link end
+linkfun(::LogLink, μ) = log(μ)
+linkinv(::LogLink, η) = exp(η)
+mueta(  ::LogLink, η) = exp(η)
+```
+and the `InverseLink` as
+```{julia;label=InverseLink;term=true}
+immutable InverseLink <: Link end
+linkfun(::InverseLink, μ) = inv(μ)
+linkinv(::InverseLink, η) = inv(η)
+mueta(  ::InverseLink, η) = -inv(abs2(η))
+```
+using the generic functions `inv`, for inverse, and `abs2` for the square.
+(Expressions like `1/μ` and `η^2` could be used instead but methods for these generic functions are carefully defined to return appropriate types for different types of numeric arguments.
+The compiler will inline short function definitions like these so there is no function call overhead in the evaluation.)
+
+These three links are all canonical links for particular distributions.
+`IdentityLink` is canonical for the normal (or Gaussian) distribution, `LogLink` is canonical for the Poisson distribution, and `InverseLink` is canonical for the gamma distribution.
+None of these definitions are in any way controversial nor do they require careful consideration of the properties of floating point operations.
+
+The first argument in a call to one of these methods is the representative object for the link.
+For example
+```{julia;label=linkcall;term=true}
+η = 1.0
+μ = linkinv(LogLink(), η)
+dμdη = mueta(LogLink(), η)
+linkfun(LogLink(), μ) ≈ η
+```
+There is no penalty for constructing the representative object when such methods are called within a function, as the compiler will elide the constructor.
+
+## Links for the Bernoulli distribution
+
+In models for binary responses the scalar distribution is [Bernoulli](https://en.wikipedia.org/wiki/Bernoulli_distribution) with μ ∈ (0, 1).
+The continuous, monotone increasing inverse link function, g⁻¹, can be regarded as the cumulative distribution function (cdf), F, of a continuous random variable with support (∞, ∞).
+We will refer to this distribution as the *inverse link generating distribution* or, more simply, the *generating distribution* for the link.
+Be careful not to confuse the generating distribution for a link with the scalar distribution, $\mathcal{D}$, of the response.
+For all the links in this section, the scalar distribution of the response is Bernoulli.
+
+Because changes of location and scale in the generating distribution will be absorbed in the fitted values of the coefficients, the standard form of the distribution is used.
+
+The nomenclature is regrettably confusing because the inverse link function, g⁻¹, is the cdf of the generating distribution and the link function, g, is the inverse cdf or *quantile* function of the generating distribution.
+It would have been a lot simpler for everyone if the names of the link function and inverse link function were chosen the other way around.
+Rest assured there is a reason for this confusing choice.
+(See the references on the canonical link for details.)
+
+The probability density of the generating distribution is the derivative of the inverse link.
+
+### The `LogitLink` from the `Logistic()` distribution
+
+In the standard form of the `Logistic` distribution
+```{julia;label=packages;term=true}
+using Distributions
+Logistic()
+```
+**both** the cdf and the quantile functions are simple, analytic expressions.
+The cdf is called the *logistic* function and its inverse is the *logit*, or *log-odds* function.
+```{julia;label=logit;term=true}
+logistic(η) = inv(1 + exp(-η))
+logit(μ) = log(μ / (1 - μ))
+abstract type Link01 <: Link end
+abstract type SymLink01 <: Link01 end
+immutable LogitLink <: SymLink01 end
+linkfun(::LogitLink, μ) = logit(μ)
+linkinv(::LogitLink, η) = logistic(η)
+```
+The pdf,
+```{julia;label=logisticpdf;term=true}
+function mueta(::LogitLink, η)
+    e = exp(abs(η))
+    ep1 = e + 1
+    (e / ep1) / ep1
+end
+```
+is symmetric about 0.
+
+The `LogitLink` is the [*canonical link*](https://en.wikipedia.org/wiki/Generalized_linear_model#Link_function) when the response is assumed to have a Bernoulli distribution.
+
+### The `ProbitLink` from the `Normal()` distribution
+
+The standard normal distribution
+```{julia;label=Normal;term=true}
+Normal()
+```
+generates the `ProbitLink`.
+Its cdf and quantile function are defined in terms of the "complementary error function", `erfc`, and its inverse, `erfcinv`, from the `StatsFuns` package.
+The [relationship](https://en.wikipedia.org/wiki/Error_function#Complementary_error_function) between these functions and the standard normal cdf is `𝚽(x) = erfc(-x/√2) / 2`.
+The constant `sqrt2` is a special type of Julia object called `Irrational` that adjusts its precision to other arguments in operator expressions.
+```{julia;label=erf;term=true}
+using SpecialFunctions: erfc, erfcinv
+Base.@irrational sqrt2     1.4142135623730950488 sqrt(big(2.0))
+Base.@irrational sqrt2π    2.5066282746310005024 sqrt(big(π) * 2.0)
+immutable ProbitLink <: Link01 end
+linkinv(::ProbitLink, η) = erfc(-η / sqrt2) / 2
+linkfun(::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
+mueta(  ::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
+```
+
+### The `CauchitLink` from the `Cauchy()` distribution
+
+The standard Cauchy distribution
+```{julia;label=Cauchy;term=true}
+Cauchy()
+```
+generates the `CauchitLink`
+```{julia;label=Cauchit;term=true}
+immutable CauchitLink <: Link01 end
+linkfun(::CauchitLink, μ) = tan(π * (μ - 1/2))
+linkinv(::CauchitLink, η) = 1/2 + atan(η) / π
+mueta(  ::CauchitLink, η) = inv(π * (abs2(η) + 1))
+```
+
+Both the standard normal and the standard Cauchy distributions are symmetric about 0.
+
+### The `CloglogLink` from the Extreme-Value distribution
+
+The cdf of the standard [Extreme Value Distribution (Type 1)](http://www.itl.nist.gov/div898/handbook/apr/section1/apr163.htm) generates the `complementary log-log link`
+```{julia;label=Cauchit;term=true}
+immutable CloglogLink <: Link01 end
+linkfun(::CauchitLink, μ) = log(-log1p(-μ))
+linkinv(::CauchitLink, η) = -expm1(-exp(η))
+mueta(  ::CauchitLink, η) = exp(η) * exp(exp(η))
+```
+This is the only common case of a generating distribution that is not symmetric about 0.
+
+## Evaluation of inverse links for the Bernoulli distribution
+
+The variance function for the Bernoulli distribution is
+\begin{equation}
+\mathcal{V}(\mu) = \mu(1 - \mu).
+\end{equation}
+Without further checks, if either $\mu$ or $1-\mu$ evaluate to zero, the IRLS algorithm will fail because the working weights will contain `NaN`.
+
+If the variance function is evaluated naively there will be an asymmetry in the range of allowed values of $\eta$ because the *relative machine precision*, which is the smallest value $\epsilon$ for which $1 - \epsilon$ evaluates to a number less than 1, is much larger than the minimum representable positive number.
+```{julia;label=eps;term=true}
+eps(Float64)
+realmin(Float64)
+1 - eps()
+1 - eps()/4
+```

--- a/docs/src/links.jmd
+++ b/docs/src/links.jmd
@@ -1,144 +1,183 @@
----
-title: Notes on link functions for GLMs
-author: Douglas Bates
-date: July 27, 2017
----
+# Numerical considerations when fitting GLMs
 
-In a generalized linear model (GLM) the *n*-dimensional random variable $\mathcal{Y}$, whose observed value is $\mathbf{y}$, the *response vector*, is modeled as independent observations from a scalar distribution family $\mathcal{D}$.
-The scalar distributions differ only in their expected values.
-If there are other parameters in the scalar distribution, $\mathcal{D}$, such as a dispersion parameter, they are assumed to be equal across the observations.
-The expected value of $\mathcal{Y}$ is modeled as
-\begin{equation}
-\mathsf{𝖤}(\mathcal{Y}) = \mathbf{\mu} = \mathbf{g}^{-1}(\mathbf{X}\mathbf{β})
-\end{equation}
-where $\mathbf{\eta}=\mathbf{X\beta}$ is the *linear predictor* formed from the $n\times p$ *model matrix*, $\mathbf{X}$, and the $p$-dimensional *coefficient vector*, $\mathbf{\beta}$, and $\mathbf{g}^{-1}$ is the vector-valued *inverse link* function.
+Before discussing computational aspects of fitting Generalized Linear Models (GLMs) it is helpful to define the linear model and see which properties are being generalized.
 
-The vector-valued *link* and *inverse link* functions are component-wise applications of a scalar link, $g$, and its inverse, $g^{-1}$, which map the possibly restricted range of the mean, $\mu$, to the unrestricted range of $\eta$ and vice-versa.
-For example, if 𝒟 is the [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution) then μ ∈ (0, ∞) while η ∈ (-∞, ∞) and typically a *log link*,
-\begin{equation}
-\eta = g(\mu) = \log(\mu),
-\end{equation}
-with inverse,
-\begin{equation}
-\mu = g^{-1}(\eta) = \exp(\eta),
-\end{equation}
-is used.
+### Properties of linear models
 
-In the linear model, which is the model generalized by the GLM, the link and its inverse are the identity function so that
+The probability model for a linear model can be written
 \begin{equation}
-\mathcal{Y}\sim\mathcal{N}(\mathbf \mu, \sigma^2\mathbf I).
+\mathcal{Y}\sim\mathcal{N}(\mathbf X \beta, \sigma^2\mathbf I)
+\end{equation}
+where the observed value of the $n$-dimensional random variable, $\mathcal{Y}$, is $\mathbf{y}$, the observed *response vector*, $\mathbf X$ is the $n\times p$ *model matrix*, $\beta$ is a $p$-dimensional coefficient vector, and $\sigma^2$ is the (scalar) dispersion parameter.
+$\mathcal{N}$ denotes the multivariate normal (or Gaussian) distribution.
+
+The individual observations are almost i.i.d. (independent and identically distributed) except that the mean value is determined by the *linear predictor* $\eta=\mathbf X\beta$.
+In fact, the mean value is the linear predictor
+\begin{equation}
+    \mu = \eta = \mathbf X\beta,
+\end{equation}
+a situation that can be described by saying there is an *identity link* between the linear predictor and the mean.
+
+### Generalized linear models
+
+The probability model for a GLM generalizes the linear model in that the distributions of the elements of $\mathcal{Y}$ are modeled as independent observations from a given distribution family, $\mathcal{D}$, and these independent variates differ only in their means.
+Furthermore the mean vector $\mu$ is determined by a linear predictor vector $\eta=\mathbf X\beta$.
+If the family $\mathcal{D}$ has a *dispersion parameter*, usually written $\phi$, it is assumed to be common to all observations.
+
+For many distributions it is not appropriate to set $\mu=\eta$ because the range of possible values of the mean is restricted whereas that of the linear predictor is unrestricted.
+For example the mean of a [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution) must be positive.
+
+To map back and forth from the possibly restricted observation scale to the unrestricted linear predictor scale an invertible scalar *link function*, $g$, is defined and applied component-wise to $\mu$.
+That is, the *link function* is $g:\mu_i\rightarrow\eta_i$ and the inverse link is $g^{-1}:\eta_i\rightarrow\mu_i$.
+
+### Some canonical links
+
+When the distribution $\mathcal{D}$ is in the [exponential family](https://en.wikipedia.org/wiki/Exponential_family) a *canonical link*, can be derived directly from the form of the distribution.
+
+In some ways it is easier to show the code for some of the canonical link functions than to show equations.
+In the implementation in the [GLM package](https://github.com/JuliaStats/GLM.jl) for Julia a `Link` is an immutable object that is used to dispatch methods for the generic functions `linkfun`, `linkinv` and `mueta`.
+
+To use distribution types from the [Distributions package](https://github.com/JuliaStats/Distributions.jl) and the abstract `Link` type, begin with
+```{julia;label=packages}
+using Distributions
+abstract type Link end
+```
+Then the `IdentityLink`, which is the canonical link for the `Normal` distribution, is defined as
+```{julia;label=IdentityLink}
+struct IdentityLink <: Link end
+linkfun(::IdentityLink, μ) = μ
+linkinv(::IdentityLink, η) = η
+mueta(  ::IdentityLink, η) = one(η) # returns an identity element of the same type as η
+canonicallink(::Normal) = IdentityLink()
+```
+and used as
+```{julia;label=simpleuse;term=true}
+linkfun(IdentityLink(), 3.0)
+mueta(IdentityLink(), 3.0)
+```
+Methods for the `mueta` generic return the derivative of the inverse link, $\frac{d\mu}{d\eta}$.
+
+The canonical link for the `Poisson` distribution is `LogLink` and for the `Gamma` distribution `InverseLink`.
+```{julia;label=LogLink}
+struct LogLink <: Link end
+linkfun(::LogLink, μ) = log(μ)
+linkinv(::LogLink, η) = exp(η)
+mueta(  ::LogLink, η) = exp(η)
+canonicallink(::Poisson) = LogLink()
+struct InverseLink <: Link end
+linkfun(::LogLink, μ) = inv(μ)
+linkinv(::LogLink, η) = inv(η)
+mueta(  ::LogLink, η) = -inv(abs2(η))
+canonicallink(::Gamma) = InverseLink()
+```
+The methods for `InverseLink` use the generic functions `inv`, for inverse, and `abs2` for the square.
+(Expressions like `1/μ` and `η^2` could be used instead but methods for the generics `inv` and `abs2` are carefully defined to return appropriate types for different types of numeric arguments.
+The compiler will inline short function definitions like these so there will be no function call overhead in the evaluation.)
+
+Finally, the canonical link for the `Bernoulli` (and also the `Binomial`) distribution is the `LogitLink`.
+For reasons described later we create intermediate abstract types `Link01` for link types where the range of $\mu$ is $0<\mu<1$ and `SymLink01` for link types whose inverse link is the cdf of a symmetric distribution.
+```{julia;label=LogitLink}
+abstract type Link01 <: Link end
+abstract type SymLink01 <: Link01 end
+struct LogitLink <: SymLink01 end
+logit(x) = log(x / 1 - x)       # the logit or log-odds function
+logistic(x) = inv(1 + exp(-x))  # cdf of the standard Logistic distribution
+linkfun(::LogitLink, μ) = logit(μ)
+linkinv(::LogitLink, η) = logistic(η)
+function mueta(  ::LogitLink, η)
+    e   = exp(-η)
+    ep1 = 1 + e
+    (e / ep1) / ep1
+end
+canonicallink(::Union{Bernoulli,Binomial}) = LogitLink()
+```
+
+It should be noted that, in the GLM context, the response for a `Binomial` distribution is the taken to be the *proportion* of successes in a number of trials.
+Hence the mean, $\mu$ is in the range $0<\mu<1$.
+
+## Evaluation of methods for links
+
+The method definitions for `IdentityLink`, `LogLink` and `InverseLink` are straightforward calls to standard arithmetic functions whose evaluation is uncontroversial.
+
+In contrast, the `LogitLink` presents some interesting computational considerations.
+
+As indicated in the comments, the `logistic` function, which is the inverse link function for `LogitLink`, is the cumulative distribution function (cdf) for the standard [logistic distribution]().
+```{julia;label=Logistic;term=true}
+Logistic()
+```
+
+In general, any inverse link for the `Bernoulli` and `Binomial` must correspond to the cdf of a continuous distribution with support $(-\infty,\infty)$ because it is a continous, differentiable and invertible function
+\begin{equation}
+g^{-1}: (-\infty, \infty) \rightarrow (0, 1)
+\end{equation}
+Such a funcion must be monotone.
+Without loss of generality it can be assumed to be monotone increasing and hence it represents such a cdf.
+
+The derivative or `mueta` function is therefore the probability density function for the logistic distribution, which is an "even" function (in the sense that $f(-x) = f(x)$) because the standard logistic distribution is symmetric about zero.
+
+### Avoiding the end-points of the range of $g^{-1}$
+
+The problem in evaluating any inverse link for the `Bernoulli` is that the value $\mu$ must be stictly inside the interval $(0,1)$ for the link to be defined.
+Furthermore, the *variance function*, $\mathcal{V}(\mu) = \mu(1-\mu)$ occurs in the denominator of an expression in the IRLS algorithm described below.
+A naive implementation of the algorithm will fail if the inverse link evaluates to zero or to one.
+
+For very large positive or negative values of $\eta$ the `logistic` function will round to zero or to one but falling outside the interval is not symmetric in $\eta$.
+The value of $\mu$ stays positive for very large negative values of $\eta$ but rounds to one for comparatively small positive $\eta$.
+```{julia;label=logisticunderflow;term=true}
+logistic(-700.0)
+logistic(+38.0)
+```
+
+The problem of being able to evaluate a cdf to a value within the interval $(0,1)$ for a long "tail" to the left but a comparatively short tail to the right is not unique to the logistic distribution.
+It is the reason for defining both the cdf, $F(η)$, and the *complementary cumulative distribution function*, $1 - F(η)$, for a distribution.
+```{julia;label=logisticcdf;term=true}
+cdf(Logistic(), 38.0)
+ccdf(Logistic(), 38.0)  # 1 - F(x) evaluated directly
+cdf(Normal(), 8.5)
+ccdf(Normal(), 8.5)
+```
+
+For the purposes of IRLS the two situations to be avoided are the variance function evaluating to zero or the derivative function evaluating to zero.
+One of the properties of a canonical link is that derivative of the inverse link is the variance function for the distribution.
+For the `LogitLink` the derivative is
+\begin{equation}
+    \frac{d\mu}{d\eta}=\frac{e^{-\eta}}{1+e^{-\eta}}\frac{1}{1+e^{-\eta}}=(1-\mu)\mu=\mathcal{V}(\mu)
 \end{equation}
 
-The scalar link and inverse link functions should be continuous and differentiable.
-To be invertible they must also be monotone.
-Without loss of generality we will assume they are monotone increasing.
+However, a naive evaluation of the variance function
+```{julia;label=naiveglmvar}
+glmvar(::Bernoulli, μ) = μ * (1 - μ)
+```
+will underflow at values of $η$ where `mueta` evaluates to a positive number.
+```{julia;label=naive;term=true}
+glmvar(Bernoulli(), linkinv(LogitLink(), 38.0))
+mueta(LogitLink(), 38.0)
+```
+
+The `mueta` method for `LogitLink` ends up evaluating $\mu(1-\mu)$ but without evaluating $1-\mu$ directly.
+
+ ## IRLS
 
 The *Iteratively Reweighted Least Squares* (IRLS) algorithm is a simple, effective method of determining the maximum likelihood estimates (mle's) of the coefficients, $\mathbf\beta$, and the dispersion parameter, $\phi$, if $\mathcal{D}$ has such a parameter.
-The iterative step, given the current $\mathbf\beta$, is to evaluate $\mathbf{\eta}=\mathbf{X\beta}$ then $\mathbf{\mu} = \mathbf{g}^{-1}(\mathbf{\eta})$ and the Jacobian $\frac{d\mathbf{\mu}}{d\mathbf{\eta}}$, which is, by definition, diagonal.
+The iterative step, given the current $\beta$, is to evaluate $\eta=\mathbf{X}\beta$ then $\mu = \mathbf{g}^{-1}(\mathbf{\eta})$ and the Jacobian $\frac{d\mu}{d\eta}$, which is, by definition, diagonal.
 The purpose is to determine an increment, `δ𝛃`, in the linear predictor scale from information on the residuals and the variance of the response on the response scale.
-The *working residuals*, `𝐫 = (dμ/d𝛈)⁻¹(𝐲 - 𝛍)` are the residuals `𝐲 - 𝛍` on the response scale transformed back to the linear predictor scale.
-The diagonal matrix of *working weights*, `𝐖 = (d𝛍/d𝛈)²𝒱⁻¹(𝛍)` is derived from the *variance function*, `𝒱(𝛍)`, of the distribution `𝒟`, which is the part of the variance that depends on the mean, 𝛍, only.
-The increment is the weighted least squares solution of `𝐗′𝐖𝐗 δ𝛃 = 𝐗′𝐫`.
+The *working residuals*, $\mathbf{r}=\left(\frac{d\mu}{d\eta}\right)^{-1}(\mathbf{y}-\mu)$ are the residuals $\mathbf{y}-\mu$ on the response scale transformed back to the linear predictor scale.
+The diagonal matrix of *working weights*, $\mathbf{W}=\left(\frac{d\mu}{d\eta}\right)^2\mathcal{V}^{-1}(\mu)$
+The increment is the weighted least squares solution to
+\begin{equation}
+    \mathbf{X}^\prime\mathbf{W}\mathbf{X} \delta\beta = \mathbf{X}^\prime\mathbf{Wr}
+\end{equation}
 
-A distribution in the [exponential family](https://en.wikipedia.org/wiki/Exponential_family) has a [*canonical link*](https://en.wikipedia.org/wiki/Generalized_linear_model#Link_function) associated with it.
-One of the properties of the canonical link is that the Jacobian of the inverse link is the variance function for the distribution.
-The expression for the working weights simplifies to
+For a canonical link the expression for the working weights simplifies to
 \begin{equation}
 \mathbf{W} = \frac{d\mu}{d\eta}
 \end{equation}
 
-## Simple link objects
+An alternative formulation of this algorithm is to use the *working response*, $\eta+\mathbf{r}$ in the weighted least squares problem whose solution is then the new parameter value.
 
-In the implementation in the [GLM package](https://github.com/JuliaStats/GLM.jl) a `Link` is an immutable object that is used to dispatch methods for the generic functions `linkfun`, `linkinv` and `mueta`.
-```{julia;label=linkdefs;term=true}
-abstract type Link end
-```
+## Other Links for the Bernoulli distribution
 
-For example, we define the `IdentityLink` as
-```{julia;label=IdentityLink;term=true}
-immutable IdentityLink <: Link end
-linkfun(::IdentityLink, μ) = μ
-linkinv(::IdentityLink, η) = η
-mueta(  ::IdentityLink, η) = one(η)  # returns the unit element of the same type as η
-```
-the `LogLink` as
-```{julia;label=LogLink;term=true}
-immutable LogLink <: Link end
-linkfun(::LogLink, μ) = log(μ)
-linkinv(::LogLink, η) = exp(η)
-mueta(  ::LogLink, η) = exp(η)
-```
-and the `InverseLink` as
-```{julia;label=InverseLink;term=true}
-immutable InverseLink <: Link end
-linkfun(::InverseLink, μ) = inv(μ)
-linkinv(::InverseLink, η) = inv(η)
-mueta(  ::InverseLink, η) = -inv(abs2(η))
-```
-using the generic functions `inv`, for inverse, and `abs2` for the square.
-(Expressions like `1/μ` and `η^2` could be used instead but methods for these generic functions are carefully defined to return appropriate types for different types of numeric arguments.
-The compiler will inline short function definitions like these so there is no function call overhead in the evaluation.)
-
-These three links are all canonical links for particular distributions.
-`IdentityLink` is canonical for the normal (or Gaussian) distribution, `LogLink` is canonical for the Poisson distribution, and `InverseLink` is canonical for the gamma distribution.
-None of these definitions are in any way controversial nor do they require careful consideration of the properties of floating point operations.
-
-The first argument in a call to one of these methods is the representative object for the link.
-For example
-```{julia;label=linkcall;term=true}
-η = 1.0
-μ = linkinv(LogLink(), η)
-dμdη = mueta(LogLink(), η)
-linkfun(LogLink(), μ) ≈ η
-```
-There is no penalty for constructing the representative object when such methods are called within a function, as the compiler will elide the constructor.
-
-## Links for the Bernoulli distribution
-
-In models for binary responses the scalar distribution is [Bernoulli](https://en.wikipedia.org/wiki/Bernoulli_distribution) with μ ∈ (0, 1).
-The continuous, monotone increasing inverse link function, g⁻¹, can be regarded as the cumulative distribution function (cdf), F, of a continuous random variable with support (∞, ∞).
-We will refer to this distribution as the *inverse link generating distribution* or, more simply, the *generating distribution* for the link.
-Be careful not to confuse the generating distribution for a link with the scalar distribution, $\mathcal{D}$, of the response.
-For all the links in this section, the scalar distribution of the response is Bernoulli.
-
-Because changes of location and scale in the generating distribution will be absorbed in the fitted values of the coefficients, the standard form of the distribution is used.
-
-The nomenclature is regrettably confusing because the inverse link function, g⁻¹, is the cdf of the generating distribution and the link function, g, is the inverse cdf or *quantile* function of the generating distribution.
-It would have been a lot simpler for everyone if the names of the link function and inverse link function were chosen the other way around.
-Rest assured there is a reason for this confusing choice.
-(See the references on the canonical link for details.)
-
-The probability density of the generating distribution is the derivative of the inverse link.
-
-### The `LogitLink` from the `Logistic()` distribution
-
-In the standard form of the `Logistic` distribution
-```{julia;label=packages;term=true}
-using Distributions
-Logistic()
-```
-**both** the cdf and the quantile functions are simple, analytic expressions.
-The cdf is called the *logistic* function and its inverse is the *logit*, or *log-odds* function.
-```{julia;label=logit;term=true}
-logistic(η) = inv(1 + exp(-η))
-logit(μ) = log(μ / (1 - μ))
-abstract type Link01 <: Link end
-abstract type SymLink01 <: Link01 end
-immutable LogitLink <: SymLink01 end
-linkfun(::LogitLink, μ) = logit(μ)
-linkinv(::LogitLink, η) = logistic(η)
-```
-The pdf,
-```{julia;label=logisticpdf;term=true}
-function mueta(::LogitLink, η)
-    e = exp(abs(η))
-    ep1 = e + 1
-    (e / ep1) / ep1
-end
-```
-is symmetric about 0.
-
-The `LogitLink` is the [*canonical link*](https://en.wikipedia.org/wiki/Generalized_linear_model#Link_function) when the response is assumed to have a Bernoulli distribution.
+There are three other continuous probability distributions from which the cdf is used as an inverse link for `Bernoulli` GLMs.
 
 ### The `ProbitLink` from the `Normal()` distribution
 
@@ -148,9 +187,12 @@ Normal()
 ```
 generates the `ProbitLink`.
 Its cdf and quantile function are defined in terms of the "complementary error function", `erfc`, and its inverse, `erfcinv`, from the `StatsFuns` package.
-The [relationship](https://en.wikipedia.org/wiki/Error_function#Complementary_error_function) between these functions and the standard normal cdf is `𝚽(x) = erfc(-x/√2) / 2`.
+The [relationship](https://en.wikipedia.org/wiki/Error_function#Complementary_error_function) between these functions and the standard normal cdf, $\Phi(x)$ is
+\begin{equation}
+\Phi(x) = \mathrm{erfc}(-x/√2) / 2
+\end{equation}
 The constant `sqrt2` is a special type of Julia object called `Irrational` that adjusts its precision to other arguments in operator expressions.
-```{julia;label=erf;term=true}
+```{julia;label=erf}
 using SpecialFunctions: erfc, erfcinv
 Base.@irrational sqrt2     1.4142135623730950488 sqrt(big(2.0))
 Base.@irrational sqrt2π    2.5066282746310005024 sqrt(big(π) * 2.0)
@@ -167,7 +209,7 @@ The standard Cauchy distribution
 Cauchy()
 ```
 generates the `CauchitLink`
-```{julia;label=Cauchit;term=true}
+```{julia;label=Cauchit}
 immutable CauchitLink <: Link01 end
 linkfun(::CauchitLink, μ) = tan(π * (μ - 1/2))
 linkinv(::CauchitLink, η) = 1/2 + atan(η) / π
@@ -179,26 +221,28 @@ Both the standard normal and the standard Cauchy distributions are symmetric abo
 ### The `CloglogLink` from the Extreme-Value distribution
 
 The cdf of the standard [Extreme Value Distribution (Type 1)](http://www.itl.nist.gov/div898/handbook/apr/section1/apr163.htm) generates the `complementary log-log link`
-```{julia;label=Cauchit;term=true}
+```{julia;label=Cauchit}
 immutable CloglogLink <: Link01 end
-linkfun(::CauchitLink, μ) = log(-log1p(-μ))
-linkinv(::CauchitLink, η) = -expm1(-exp(η))
-mueta(  ::CauchitLink, η) = exp(η) * exp(exp(η))
+linkfun(::CloglogLink, μ) = log(-log1p(-μ))
+linkinv(::CloglogLink, η) = -expm1(-exp(η))
+mueta(  ::CloglogLink, η) = exp(η) * exp(exp(η))
 ```
 This is the only common case of a generating distribution that is not symmetric about 0.
 
-## Evaluation of inverse links for the Bernoulli distribution
+## Implementation of IRLS
 
-The variance function for the Bernoulli distribution is
-\begin{equation}
-\mathcal{V}(\mu) = \mu(1 - \mu).
-\end{equation}
-Without further checks, if either $\mu$ or $1-\mu$ evaluate to zero, the IRLS algorithm will fail because the working weights will contain `NaN`.
-
-If the variance function is evaluated naively there will be an asymmetry in the range of allowed values of $\eta$ because the *relative machine precision*, which is the smallest value $\epsilon$ for which $1 - \epsilon$ evaluates to a number less than 1, is much larger than the minimum representable positive number.
-```{julia;label=eps;term=true}
-eps(Float64)
-realmin(Float64)
-1 - eps()
-1 - eps()/4
+The [GLM package](https://github.com/JuliaStats/GLM.jl) defines a templated struct to hold the various vectors to be updated in IRLS.
+```{julia;label=GLMResp}
+const FPVector = Vector{T} where {T<:AbstractFloat}
+struct GlmResp{V<:FPVector,D<:UnivariateDistribution,L<:Link}
+    y::V          # response vector
+    d::D
+    devresid::V   # squared deviance residuals
+    η::V          # linear predictor
+    μ::V          # mean response
+    offset::V     # offset added to `Xβ` to form `η`.  Can be of length 0.
+    wts::V        # prior case weights.  Can be of length 0.
+    wrkwt::V      # working case weights for IRLS
+    wrkresid::V   # working residuals for IRLS"
+end
 ```

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -11,7 +11,7 @@ beta = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 
 ## Create linear predictor and mean response
 eta = mm.m * beta;
-mu = [linkinv(LogitLink(), x) for x in eta]
+mu = [inv(1 + exp(-x)) for x in eta]
 y = Float64[rand() < μ for μ in mu];        # simulate observed responses
 
 gm6 = glm(mm.m, y, Binomial())

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,21 +1,21 @@
 using GLM, DataFrames
-glm(@formula(y ~ 1), DataFrame(y = float.(bitrand(10))), Binomial())
+glm(@formula(y ~ 1), DataFrame(y = float.(bitrand(10))), Bernoulli())
 
-n = 2_500_000; srand(1234321)
+n = 2_500_000; srand(1234321);
 df2 = DataFrame(x1 = rand(Normal(), n),
                 x2 = rand(Exponential(), n),
                 ss = pool(rand(DiscreteUniform(50), n)));
-mf = ModelFrame(@formula(x1 ~ x1 + x2 + ss), df2)
-mm = ModelMatrix(mf)
+mf = ModelFrame(@formula(x1 ~ x1 + x2 + ss), df2);
+mm = ModelMatrix(mf);
 beta = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 
 ## Create linear predictor and mean response
 eta = mm.m * beta;
-mu = [inv(1 + exp(-x)) for x in eta]
+mu = [inv(1 + exp(-x)) for x in eta];
 y = Float64[rand() < μ for μ in mu];        # simulate observed responses
 
-gm6 = glm(mm.m, y, Binomial())
-@time glm(mm.m, y, Binomial());
+gm6 = glm(mm.m, y, Bernoulli())
+@time glm(mm.m, y, Bernoulli());
 #@profile glm(mm.m, y, Binomial());
 #using ProfileView
 #ProfileView.view()

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,5 +1,5 @@
 using GLM, DataFrames
-glm(@formula(y ~ 1), DataFrame(y = float(bitrand(10))), Binomial())
+glm(@formula(y ~ 1), DataFrame(y = float.(bitrand(10))), Binomial())
 
 n = 2_500_000; srand(1234321)
 df2 = DataFrame(x1 = rand(Normal(), n),

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -7,13 +7,11 @@ module GLM
     using Base.LinAlg.BLAS: gemm!, gemv!
     using Base.LinAlg: QRCompactWY, Cholesky
     using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel
-    using StatsFuns: logit, logistic
     using Distributions: sqrt2, sqrt2π
     using Compat
 
     import Base: (\), cholfact, convert, cor, show, size
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual, loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, fit, model_response, r2, r², adjr2, adjr², PValue
-    import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual, loglikelihood, nobs, stderr, vcov, residuals, predict, fit, fit!, model_response, r2, r², adjr2, adjr²
 

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -6,6 +6,7 @@ module GLM
     using Base.LinAlg.LAPACK: potrf!, potrs!
     using Base.LinAlg.BLAS: gemm!, gemv!
     using Base.LinAlg: QRCompactWY, Cholesky
+    using StatsFuns: logit, logistic, xlogy
     using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel
     using Distributions: sqrt2, sqrt2π
     using Compat
@@ -27,6 +28,7 @@ module GLM
         InverseLink,
         LinearModel,
         Link,
+        Link01,
         LinPred,
         LinPredModel,
         LogitLink,

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -5,7 +5,7 @@ module GLM
     @reexport using Distributions
     using Base.LinAlg.LAPACK: potrf!, potrs!
     using Base.LinAlg.BLAS: gemm!, gemv!
-    using Base.LinAlg: QRCompactWY, Cholesky, BlasReal
+    using Base.LinAlg: QRCompactWY, Cholesky
     using StatsBase: StatsBase, CoefTable, StatisticalModel, RegressionModel
     using StatsFuns: logit, logistic
     using Distributions: sqrt2, sqrt2π

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -1,55 +1,166 @@
-@compat abstract type Link end     # Link types define linkfun!, linkinv!, and mueta!
+"""
+    Link
 
-type CauchitLink  <: Link end
-type CloglogLink  <: Link end
-type IdentityLink <: Link end
-type InverseLink  <: Link end
-type LogitLink    <: Link end
-type LogLink      <: Link end
-type ProbitLink   <: Link end
-type SqrtLink     <: Link end
+An abstract type whose subtypes determine methods for [`linkfun`](@ref), [`linkinv`](@ref),
+and [`mueta`](@ref).
+"""
+@compat abstract type Link end
 
-# copied from StatsFuns package to avoid loading the entire package
-xlogy{T<:Real}(x::T, y::T) = x > zero(T) ? x * log(y) : zero(log(x))
-xlogy(x::Real, y::Real) = xlogy(promote(x, y)...)
+"""
+    Link01
+
+An abstract type of [`Link`](@ref) for which the range of [`linkinv`](@ref) is (0, 1).  As
+such, the [`linkinv`](@ref) can be regarded as the cumulative distribution function (`cdf`)
+of a continuous distribution with support (-∞, ∞). Most `Link01` subtypes are defined by a
+distribution like this.
+
+Typically such a link is used with a `Bernoulli` or `Binomial` distribution for the response
+and the [`glmvar`](@ref) method returns `μ * (1 - μ)`.  To avoid returning a variance of
+zero, a [`linkinvcomplement`] method is defined to return a tuple `(min(μ, 1 - μ), c)` where
+`c` is a `Bool` indicating if the complement, `1 - μ`, is being returned.
+"""
+@compat abstract type Link01 <: Link end
+
+"""
+    CauchitLink
+
+A [`Link01`](@ref) corresponding to the standard Cauchy distribution,
+[`Distributions.Cauchy`](@ref).
+"""
+type CauchitLink  <: Link01 end
+
+"""
+    CloglogLink
+
+A [`Link01`](@ref) corresponding to the extreme value (or log-Wiebull) distribution.  The
+inverse link is called the complementary log-log transformation, `1 - exp(-exp(η))`.
+"""
+type CloglogLink  <: Link01 end
+
+"""
+    IdentityLink
+
+The canonical [`Link`](@ref) for the `Normal` distribution, defined as `μ = η`.
+"""
+type IdentityLink <: Link   end
+
+"""
+    InverseLink
+
+The canonical [`Link`](@ref) for the `Gamma` distribution, defined as `μ = inv(η)`.
+"""
+type InverseLink  <: Link   end
+
+"""
+    LogitLink
+
+The canonical [`Link01`](@ref) for the `Bernoulli` and `Binomial` distributions,
+The inverse link, [`linkinv`](@ref), is the c.d.f. of the standard logistic distribution,
+(`Distributions.Logistic()`).
+"""
+type LogitLink    <: Link01 end
+
+"""
+    LogLink
+
+The canonical [`Link`](@ref) for the [`Poisson`](@ref) distribution, defined as `η = log(μ)`.
+"""
+type LogLink      <: Link   end
+
+"""
+    ProbitLink
+
+A [`Link01`](@ref) whose [`linkinv`](@ref) is the c.d.f. of the standard normal
+distribution, (`Distributions.Normal()`).
+"""
+type ProbitLink   <: Link01 end
+
+"""
+    SqrtLink
+
+A [`Link`](@ref) for which the [`linkfun`] is `η = √μ`
+"""
+type SqrtLink     <: Link   end
 
 # x + 1 preserving the type of x
 xp1(x) = x + one(x)
 
-linkfun(::CauchitLink, μ) = tan(pi * (μ - oftype(μ, 1/2)))
-linkinv(::CauchitLink, η) = (oftype(η, 1/2) + atan(η) / pi, false)
-mueta(  ::CauchitLink, η) = inv(pi * xp1(abs2(η)))
+# default inverse link for cases where inverselinkorcomplement is defined
+function linkinv(L::Link01, η)
+    μ, c = linkinvcomplement(L, η)
+    c ? one(μ) - μ : μ
+end
 
-linkfun(::CloglogLink, μ) = log(-log1p(-μ))
-linkinv(::CloglogLink, η) = η < 0 ? (-expm1(-exp(η)), false) : (exp(-exp(η)), true)
-mueta(  ::CloglogLink, η) = exp(η) * exp(-exp(η))
+linkfun(          ::CauchitLink, μ) = tan(pi * (μ - oftype(μ, 1/2)))
+linkinvcomplement(::CauchitLink, η) = (oftype(η, 1/2) + atan(η) / pi, false)
+mueta(            ::CauchitLink, η) = inv(pi * xp1(abs2(η)))
+
+linkfun(          ::CloglogLink, μ) = log(-log1p(-μ))
+linkinvcomplement(::CloglogLink, η) = η < 0 ? (-expm1(-exp(η)), false) : (exp(-exp(η)), true)
+mueta(            ::CloglogLink, η) = exp(η) * exp(-exp(η))
 
 linkfun(::IdentityLink, μ) = μ
-linkinv(::IdentityLink, η) = (η, false)
+linkinv(::IdentityLink, η) = η
 mueta(  ::IdentityLink, η) = one(η)
 
 linkfun(::InverseLink, μ) = inv(μ)
-linkinv(::InverseLink, η) = (inv(η), false)
+linkinv(::InverseLink, η) = inv(η)
 mueta(  ::InverseLink, η) = -inv(abs2(η))
 
-linkfun(::LogitLink, μ) = log(μ / (one(μ) - μ))
-linkinv(::LogitLink, η) = (inv(xp1(exp(-abs(η)))), η > 0)
-function mueta(::LogitLink, η)
-    e = exp(-abs(η))
+linkfun(          ::LogitLink, μ) = log(μ / (one(μ) - μ))
+linkinvcomplement(::LogitLink, η) = (inv(xp1(exp(abs(η)))), η > 0)
+function mueta(   ::LogitLink, η)
+    e = exp(abs(η))
     e / abs2(xp1(e))
 end
 
 linkfun(::LogLink, μ) = log(μ)
-linkinv(::LogLink, η) = (exp(η), false)
+linkinv(::LogLink, η) = exp(η)
 mueta(  ::LogLink, η) = exp(η)
 
-linkfun(::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
-linkinv(::ProbitLink, η) = (erfc(abs(η) / sqrt2) / 2, η > 0)
-mueta(  ::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
+linkfun(          ::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
+linkinvcomplement(::ProbitLink, η) = (erfc(abs(η) / sqrt2) / 2, η > 0)
+mueta(            ::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
 
 linkfun(::SqrtLink, μ) = sqrt(μ)
-linkinv(::SqrtLink, η) = (abs2(η), false)
+linkinv(::SqrtLink, η) = abs2(η)
 mueta(  ::SqrtLink, η) = 2η
+
+"""
+    linkfun(L::Link, μ)
+
+Return `η`, the value of the linear predictor for link `L` at mean `μ`.
+"""
+function linkfun end
+
+"""
+    linkinv(L::Link, η)
+
+Return `μ`, the mean value, for link `L` at linear predictor value `η`.
+"""
+function linkinv end
+
+"""
+    linkinvcomplement(L::Link01, η)
+
+Return a tuple of `μ`, the mean value, or its complement, `1 - μ`, for link `L` at linear
+predictor value `η` plus a [`Bool`](@ref) indicator for the complement.
+"""
+function linkinv end
+
+"""
+    mueta(L::Link, η)
+
+Return the derivative of [`linkinv`](@ref), `dμ/dη`, for link `L` at linear predictor value `η`.
+"""
+function mueta end
+
+"""
+    canonicallink(D::Distribution)
+
+Return the canonical link for distribution `D`, which must be in the exponential family.
+"""
+function canonicallink end
 
 canonicallink(::Bernoulli) = LogitLink()
 canonicallink(::Binomial)  = LogitLink()
@@ -57,21 +168,53 @@ canonicallink(::Gamma)     = InverseLink()
 canonicallink(::Normal)    = IdentityLink()
 canonicallink(::Poisson)   = LogLink()
 
-glmvar(::Union{Bernoulli,Binomial}, ::Link, μ) = μ * (1 - μ)
-glmvar(::Gamma,                     ::Link, μ) = abs2(μ)
-glmvar(::Normal,                    ::Link, μ) = one(μ)
-glmvar(::Poisson,                   ::Link, μ) = μ
+"""
+    glmvar(D::Distribution, μ)
 
+Return the variance function for distribution `D` evaluated at mean value `μ`.
+
+The variance function is the part of the variance that depends upon `μ`.  The
+variance of the response may be a multiple of this value but the multiple cannot
+depend upon `μ`.
+"""
+glmvar(::Union{Bernoulli,Binomial}, μ) = μ * (1 - μ)
+glmvar(::Gamma,                     μ) = abs2(μ)
+glmvar(::Normal,                    μ) = one(μ)
+glmvar(::Poisson,                   μ) = μ
+
+"""
+    mustart(D::Distribution, y, wt)
+
+Return a suitable starting value for `μ` in distribution `D` given the response `y`.
+
+Often a suitable value is `y`.  These methods exist to handle "corner cases" where, e.g.
+the response `y` may be 0 but `μ` must be positive.
+
+The `wt` argument is only used when `D` is `Binomial`.  For the purposes of GLMs a
+`Binomial` response is the proportion of successes in `n` trials and `n` is used as a
+case weight.
+"""
 mustart(::Bernoulli, y, wt) = (y + oftype(y, 1/2)) / 2
 mustart(::Binomial , y, wt) = (wt * y + oftype(y, 1/2)) / xp1(wt)
 mustart(::Gamma    , y, wt) = y == 0 ? oftype(y, 0.1) : y
 mustart(::Normal   , y, wt) = y
 mustart(::Poisson  , y, wt) = y + oftype(y, 0.1)
 
+"""
+    devresid(D::Distribution, y, μ)
+
+Return the squared deviance residual of `y` and `μ` for distribution `D`.
+
+The deviance for the parameters in a GLM is the sum of these squared deviance residuals
+evaluated at the current `β`.
+
+This name, matching that in R, is confusing because the deviance residuals are
+`sign(y - μ) * sqrt(devresid(D, y, μ))`.
+"""
 function devresid(::Bernoulli, y, μ)
     if y == 1  # change to isone when lower bound on Julia version is 0.7
         return -2 * log(μ)
-    elseif iszero(y)
+    elseif y == 0
         return -2 * log1p(-μ)
     end
     throw(ArgumentError("y should be 0 or 1 (got $y)"))
@@ -79,7 +222,7 @@ end
 function devresid(::Binomial, y, μ)
     if y == 1
         return -2 * log(μ)
-    elseif iszero(y)
+    elseif y == 0
         return -2 * log1p(-μ)
     else
         return 2 * (y * (log(y) - log(μ)) + (1 - y)*(log1p(-y) - log1p(-μ)))
@@ -93,7 +236,12 @@ devresid(::Poisson, y, μ) = 2 * (xlogy(y, y / μ) - (y - μ))
 dispersion_parameter(::Union{Bernoulli, Binomial, Poisson})   = false
 dispersion_parameter(::Union{Gamma, Normal, InverseGaussian}) = true
 
-# Log-likelihood for an observation
+"""
+    loglik_obs(D::Distribution, y, μ, wt, ϕ)
+
+Return the log-likelihood contribution for `y` under distribution `D` with mean `μ`,
+scale parameter `ϕ` and case weight `wt`.
+"""
 loglik_obs(::Bernoulli, y, μ, wt, ϕ) = wt*logpdf(Bernoulli(μ), y)
 loglik_obs(::Binomial , y, μ, wt, ϕ) = logpdf(Binomial(Int(wt), μ), Int(y*wt))
 loglik_obs(::Gamma    , y, μ, wt, ϕ) = wt*logpdf(Gamma(1/ϕ, μ*ϕ), y)

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -15,7 +15,7 @@ function installbeta!(p::LinPred, f::Real=1.)
     p.beta0
 end
 
-type DensePredQR{T<:BlasReal} <: DensePred
+type DensePredQR{T<:Real} <: DensePred
     X::Matrix{T}                  # model matrix
     beta0::Vector{T}              # base coefficient vector
     delbeta::Vector{T}            # coefficient increment
@@ -30,12 +30,12 @@ end
 (::Type{DensePredQR})(X::Matrix, beta0::Vector) = DensePredQR{eltype(X)}(X, beta0)
 convert{T}(::Type{DensePredQR{T}}, X::Matrix{T}) = DensePredQR{T}(X, zeros(T, size(X, 2)))
 
-function delbeta!{T<:BlasReal}(p::DensePredQR{T}, r::Vector{T})
+function delbeta!{T<:Real}(p::DensePredQR{T}, r::Vector{T})
     p.delbeta = p.qr\r
     return p
 end
 
-type DensePredChol{T<:BlasReal,C} <: DensePred
+type DensePredChol{T<:Real,C} <: DensePred
     X::Matrix{T}                   # model matrix
     beta0::Vector{T}               # base vector for coefficients
     delbeta::Vector{T}             # coefficient increment
@@ -75,12 +75,12 @@ else
     Base.LinAlg.cholfact!{T<:FP}(p::DensePredQR{T}) = Cholesky{T,typeof(p.X)}(p.qr[:R], 'U', 0)
 end
 
-function delbeta!{T<:BlasReal}(p::DensePredChol{T}, r::Vector{T})
+function delbeta!{T<:Real}(p::DensePredChol{T}, r::Vector{T})
     A_ldiv_B!(p.chol, At_mul_B!(p.delbeta, p.X, r))
     p
 end
 
-function delbeta!{T<:BlasReal}(p::DensePredChol{T}, r::Vector{T}, wt::Vector{T})
+function delbeta!{T<:Real}(p::DensePredChol{T}, r::Vector{T}, wt::Vector{T})
     scr = scale!(p.scratch, wt, p.X)
     if VERSION < v"0.5.0-dev+4677"
         cholfact!(At_mul_B!(cholfactors(p.chol), scr, p.X), :U)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -368,9 +368,9 @@ end
     nullmod = lm(@formula(Result~1), d).model
     @test GLM.issubmodel(nullmod, mod)
     @test !GLM.issubmodel(othermod, mod)
-    
+
     @test_throws ArgumentError ftest(mod, othermod)
-    
+
     ft = ftest(mod, nullmod)
     @test isapprox(ft.pval[1].v,  2.481215056713184e-8)
     # Test output
@@ -380,7 +380,7 @@ end
         Model 1       10   3      0.1283          0.9603                      
         Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
         """
-    
+
     bigmod = lm(@formula(Result~Treatment+Other), d).model
     ft2 = ftest(bigmod, mod, nullmod)
     @test isapprox(ft2.pval[2].v,  2.481215056713184e-8)


### PR DESCRIPTION
Introduce complementary return value in `linkinv` indicating when the complimentary
inverse link function has been evaluated instead of the inverse link function.
This greatly improves the range for which the linear predictor gives non-zero
variance components.

This PR also changes the convergence criterion to use absolute difference alongside relative difference.
This is useful when data is completely separated.

@dmbates This will greatly improve the accuracy of the `glmvar` evaluation in the `CloglogLink`
case. More generally, it also simplifies the code and avoids computing μ twice so there should be
a (slight) speedup here in the non-canonical link case. The cost is that `linkinv` returns a tuple of two arguments
which might be a little inconvenient but since it is mainly an internal helper function I guess it is okay.

I think we have discussed earlier what can be assumed about `(dμ/dη)/glmvar` but I've now convinced myself
that we can avoid clamping the values and instead assume that `0/0=0`. For the score contributions in the binomial case,
the computations are something like (sorry about ∂s. I forgot that these aren't partials)

![image](https://user-images.githubusercontent.com/505001/28534873-3f0c5360-7070-11e7-92d8-93f04a5c9de0.png)

so in practice, I'm setting `wrkresid` to zero when a `NaN` is detected to neutralize the score contribution. For the variance
weight, the computation is something like

![image](https://user-images.githubusercontent.com/505001/28536360-5e4e585e-7075-11e7-809a-7a8d3f814546.png)

So as long as the second derivative of μ has limit zero when η goes to infinity, we should be fine. I think that should always be the case.

Similar situations can happen for the Poisson when μ goes to zero but substituting `NaN`s with zeros should be okay
under a similar condition on the second derivative (going to negative infinity).

@dmbates I'm fine with analyzing all the relevant cases but I'm not sure which non-canonical link functions are common outside the binomial model. Do you think there are relevant cases where these assumptions won't hold?