### PR TITLE
Evaluate inverse link and its derivative simultaneously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs/build
+docs/site

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 julia:
     - 0.5
     - 0.6
-    - nightly
+#    - nightly   Still a problem with StatsFuns package on nightly
 notifications:
     email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 julia:
     - 0.5
     - 0.6
-#    - nightly   Still a problem with StatsFuns package on nightly
+    - nightly
 notifications:
     email: false
 sudo: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.18.0
 Distributions 0.10.0
 StatsBase 0.12.0

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,3 @@
+using Documenter, GLM
+
+makedocs()

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,30 @@
+site_name:        GLM.jl
+repo_url:         https://github.com/JuliaStats/GLM.jl
+site_description: Fit and examine generalized linear models
+site_author:      JuliaStats
+
+theme: material
+
+extra:
+  palette:
+    primary: 'indigo'
+    accent:  'blue'
+
+extra_css:
+  - assets/Documenter.css
+
+extra_javascript:
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - assets/mathjaxhelper.js
+
+markdown_extensions:
+  - codehilite
+  - extra
+  - tables
+  - fenced_code
+  - mdx_math
+
+docs_dir: 'build'
+
+pages:
+- Home: index.md

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,12 @@
+# GLM.jl Documentation
+
+```@meta
+CurrentModule = GLM
+```
+
+```@docs
+linkfun
+linkinv
+mueta
+inverselink
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,9 @@
 
 ```@meta
 CurrentModule = GLM
+DocTestSetup = quote
+    using GLM
+end
 ```
 
 ```@docs

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -12,7 +12,7 @@ const β = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 
 ## Create linear predictor and mean response
 
-const y = Float64[rand() < logistic(η) for η in mm.m * β];        # simulate observed responses
+const y = [float(rand() < logistic(η)) for η in mm.m * β];        # simulate observed responses
 
 gm6 = glm(mm.m, y, Bernoulli())
 @time glm(mm.m, y, Bernoulli());

--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,21 +1,21 @@
-using GLM, DataFrames
-glm(@formula(y ~ 1), DataFrame(y = float(bitrand(10))), Binomial())
+using GLM, DataFrames, StatsFuns
+glm(@formula(y ~ 1), DataFrame(y = float(bitrand(10))), Bernoulli())
 
-n = 2_500_000; srand(1234321)
-df2 = DataFrame(x1 = rand(Normal(), n),
+n = 2_500_000
+srand(1234321)
+const df2 = DataFrame(x1 = rand(Normal(), n),
                 x2 = rand(Exponential(), n),
                 ss = pool(rand(DiscreteUniform(50), n)));
-mf = ModelFrame(@formula(x1 ~ x1 + x2 + ss), df2)
-mm = ModelMatrix(mf)
-beta = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
+const mf = ModelFrame(@formula(x1 ~ x1 + x2 + ss), df2)
+const mm = ModelMatrix(mf)
+const β = unshift!(rand(Normal(),52), 0.5); # "true" parameter values
 
 ## Create linear predictor and mean response
-eta = mm.m * beta;
-mu = [linkinv(LogitLink(), x) for x in eta]
-y = Float64[rand() < μ for μ in mu];        # simulate observed responses
 
-gm6 = glm(mm.m, y, Binomial())
-@time glm(mm.m, y, Binomial());
+const y = Float64[rand() < logistic(η) for η in mm.m * β];        # simulate observed responses
+
+gm6 = glm(mm.m, y, Bernoulli())
+@time glm(mm.m, y, Bernoulli());
 #@profile glm(mm.m, y, Binomial());
 #using ProfileView
 #ProfileView.view()

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -27,6 +27,7 @@ module GLM
         GlmResp,
         IdentityLink,
         InverseLink,
+        InverseSquareLink,
         LinearModel,
         Link,
         LinPred,

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -45,17 +45,20 @@ module GLM
         devresid,       # vector of squared deviance residuals
         formula,        # extract the formula from a model
         glm,            # general interface
+        glmvar,         # the variance function
         inverselink,    # returns μ, dμ/dη and, when appropriate, μ*(1-μ)
         linkfun,        # link function mapping mu to eta, the linear predictor
         linkinv,        # inverse link mapping eta to mu
         linpred,        # linear predictor
-        linpred!,       # update the linear predictor
+        linpred!,       # update the linear predictor in place
         lm,             # linear model
+        logistic,
+        logit,
         mueta,          # derivative of inverse link
         mustart,        # derive starting values for the mu vector
         nobs,           # total number of observations
         predict,        # make predictions
-        updateμ!,      # update the response type from the linear predictor
+        updateμ!,       # update the response type from the linear predictor
         wrkresp,        # working response
         ftest           # compare models with an F test
 

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -44,6 +44,7 @@ module GLM
         devresid,       # vector of squared deviance residuals
         formula,        # extract the formula from a model
         glm,            # general interface
+        inverselink,    # returns μ, dμ/dη and, when appropriate, μ*(1-μ)
         linkfun,        # link function mapping mu to eta, the linear predictor
         linkinv,        # inverse link mapping eta to mu
         linpred,        # linear predictor

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -65,16 +65,26 @@ this is an ANOVA, our null hypothesis is that `Result~1` fits the data as well a
 
 ```jldoctest
 julia> dat = DataFrame(Treatment=[1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2.],
-                       Result=[1.1, 1.2, 1, 2.2, 1.9, 2, .9, 1, 1, 2.2, 2, 2]);
+                       Result=[1.1, 1.2, 1, 2.2, 1.9, 2, .9, 1, 1, 2.2, 2, 2],
+                       Other=[1, 1, 2, 1, 2, 1, 3, 1, 1, 2, 2, 1]);
 
 julia> mod = lm(@formula(Result~Treatment), dat);
 
 julia> nullmod = lm(@formula(Result~1), dat);
 
+julia> bigmod = lm(@formula(Result~1 + Treatment + Other), dat);
+
 julia> ft = ftest(mod.model, nullmod.model)
-        Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F* p(>F)
-Model 1       10   3      0.1283          0.9603                      
-Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
+        Res. DOF DOF ΔDOF    SSR    ΔSSR     R²    ΔR²       F* p(>F)
+Model 1       10   3      0.1283         0.9603
+Model 2       11   2   -1 3.2292 -3.1008 0.0000 0.9603 241.6234 <1e-7
+
+
+julia> ftest(bigmod.model, mod.model, nullmod.model)
+        Res. DOF DOF ΔDOF    SSR    ΔSSR     R²    ΔR²       F*  p(>F)
+Model 1        9   4      0.1038         0.9678
+Model 2       10   3   -1 0.1283 -0.0245 0.9603 0.0076   2.1236 0.1790
+Model 3       11   2   -1 3.2292 -3.1008 0.0000 0.9603 241.6234  <1e-7
 ```
 """
 function ftest(mods::LinearModel...)

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -60,19 +60,19 @@ and p-value for the comparison between the two models.
 # Examples
 
 Suppose we want to compare the effects of two or more treatments on some result. Because
-this is an ANOVA, our null hypothesis is that `Result~1` fits the data as well as
-`Result~Treatment`.
+this is an ANOVA, our null hypothesis is that `Result ~ 1` fits the data as well as
+`Result ~ 1 + Treatment`.
 
 ```jldoctest
 julia> dat = DataFrame(Treatment=[1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2.],
                        Result=[1.1, 1.2, 1, 2.2, 1.9, 2, .9, 1, 1, 2.2, 2, 2],
                        Other=[1, 1, 2, 1, 2, 1, 3, 1, 1, 2, 2, 1]);
 
-julia> mod = lm(@formula(Result~Treatment), dat);
+julia> mod = lm(@formula(Result ~ 1 + Treatment), dat);
 
-julia> nullmod = lm(@formula(Result~1), dat);
+julia> nullmod = lm(@formula(Result ~ 1), dat);
 
-julia> bigmod = lm(@formula(Result~1 + Treatment + Other), dat);
+julia> bigmod = lm(@formula(Result ~ 1 + Treatment + Other), dat);
 
 julia> ft = ftest(mod.model, nullmod.model)
         Res. DOF DOF ΔDOF    SSR    ΔSSR     R²    ΔR²       F* p(>F)

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -17,7 +17,7 @@ function issubmodel(mod1::LinPredModel, mod2::LinPredModel)
     pred2 = mod2.pp.X
     npreds2 = size(pred1, 2)
     # If model 1 has more predictors, it can't possibly be a submodel
-    npreds1 > npreds2 && return false 
+    npreds1 > npreds2 && return false
 
     @inbounds for i in 1:npreds1
         var_in_mod2 = false
@@ -29,7 +29,7 @@ function issubmodel(mod1::LinPredModel, mod2::LinPredModel)
         end
 
         if !var_in_mod2 # We have found a predictor variable in model 1 that is not in model 2
-            return false 
+            return false
         end
     end
 
@@ -45,7 +45,7 @@ dividetuples{N}(t1::NTuple{N}, t2::NTuple{N}) = ntuple(i->t1[i]/t2[i], N)
 """
     ftest(mod::LinearModel...)
 
-For each sequential pair of linear predictors in `mod`, perform an F-test to determine if 
+For each sequential pair of linear predictors in `mod`, perform an F-test to determine if
 the first one fits significantly better than the next.
 
 A table is returned containing residual degrees of freedom (DOF), degrees of freedom,
@@ -62,7 +62,7 @@ and p-value for the comparison between the two models.
 Suppose we want to compare the effects of two or more treatments on some result. Because
 this is an ANOVA, our null hypothesis is that `Result~1` fits the data as well as
 `Result~Treatment`.
- 
+
 ```jldoctest
 julia> dat = DataFrame(Treatment=[1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2.],
                        Result=[1.1, 1.2, 1, 2.2, 1.9, 2, .9, 1, 1, 2.2, 2, 2]);
@@ -75,11 +75,12 @@ julia> ft = ftest(mod.model, nullmod.model)
         Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F* p(>F)
 Model 1       10   3      0.1283          0.9603                      
 Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
+```
 """
 function ftest(mods::LinearModel...)
     nmodels = length(mods)
     for i in 2:nmodels
-        issubmodel(mods[i], mods[i-1]) || 
+        issubmodel(mods[i], mods[i-1]) ||
         throw(ArgumentError("F test $i is only valid if model $i is nested in model $(i-1)"))
     end
 
@@ -106,7 +107,7 @@ function show{N}(io::IO, ftr::FTestResult{N})
     nc = 10
     nr = N
     outrows = Matrix{String}(nr+1, nc)
-    
+
     outrows[1, :] = ["", "Res. DOF", "DOF", "ΔDOF", "SSR", "ΔSSR",
                      "R²", "ΔR²", "F*", "p(>F)"]
 
@@ -114,7 +115,7 @@ function show{N}(io::IO, ftr::FTestResult{N})
                      @sprintf("%.0d", ftr.dof[1]), " ",
                      @sprintf("%.4f", ftr.ssr[1]), " ",
                      @sprintf("%.4f", ftr.r2[1]), " ", " ", " "]
-    
+
     for i in 2:nr
         outrows[i+1, :] = ["Model $i", @sprintf("%.0d", ftr.dof_resid[i]),
                            @sprintf("%.0d", ftr.dof[i]), @sprintf("%.0d", Δdof[i-1]),
@@ -129,12 +130,12 @@ function show{N}(io::IO, ftr::FTestResult{N})
         for c in 1:nc
             cur_cell = outrows[r, c]
             cur_cell_len = length(cur_cell)
-            
+
             padding = " "^(max_colwidths[c]-cur_cell_len)
-            if c > 1 
+            if c > 1
                 padding = " "*padding
             end
-            
+
             print(io, padding)
             print(io, cur_cell)
         end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -319,7 +319,7 @@ Form the predicted response of model `mm` from covariate values `newX` and, opti
 an offset.
 """
 function predict(mm::AbstractGLM, newX::AbstractMatrix;
-                 offset::FPVector=eltype(newX)}[])
+                 offset::FPVector=eltype(newX)[])
     eta = newX * coef(mm)
     if !isempty(mm.rr.offset)
         length(offset) == size(newX, 1) ||

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -26,7 +26,7 @@ end
 function GlmResp{V<:FPVector, D, L}(y::V, d::D, l::L, η::V, μ::V, off::V, wts::V)
     if d == Binomial()
         for yy in y
-            0. <= yy <= 1. || throw(ArgumentError("$yy in y is not in [0,1]"))
+            0 ≤ yy ≤ 1 || throw(ArgumentError("$yy in y is not in [0,1]"))
         end
     else
         all(x -> insupport(d, x), y) || throw(ArgumentError("y must be in the support of D"))
@@ -296,11 +296,11 @@ Distributions.Distribution(m::GeneralizedLinearModel) = Distribution(m.rr)
 """
     dispersion(m::AbstractGLM, sqr::Bool=false)
 
-Estimated dispersion (or scale) parameter for a model's distribution,
-generally written σ for linear models and ϕ for generalized linear models.
+Return the estimated dispersion (or scale) parameter for a model's distribution,
+generally written σ² for linear models and ϕ for generalized linear models.
 It is, by definition, equal to 1 for the Bernoulli, Binomial, and Poisson families.
 
-If `sqr` is `true`, the squared parameter is returned.
+If `sqr` is `true`, the squared dispersion parameter is returned.
 """
 function dispersion(m::AbstractGLM, sqr::Bool=false)
     r = m.rr

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -51,12 +51,11 @@ deviance(r::GlmResp) = sum(r.devresid)
 Returns `true` if `L` is the canonical link for distribution `D`
 """
 iscanonical(::GlmResp) = false
-iscanonical{T}(::GlmResp{Vector{T},Bernoulli{T},LogitLink}) = true
-iscanonical{T}(::GlmResp{Vector{T},Binomial{T},LogitLink}) = true
+iscanonical{V,D<:Union{Bernoulli,Binomial}}(::GlmResp{V,D,LogitLink}) = true
 #iscanonical{T}(::GlmResp{Vector{T},Gamma{T},InverseLink}) = true
 #iscanonical{T}(::GlmResp{Vector{T},InverseGaussian{T},InverseSquareLink}) = true
-iscanonical{T}(::GlmResp{Vector{T},Normal{T},IdentityLink}) = true
-iscanonical{T}(::GlmResp{Vector{T},Poisson{T},LogLink}) = true
+iscanonical{V,D<:Normal}(::GlmResp{V, D,IdentityLink}) = true
+iscanonical{V,D<:Poisson}(::GlmResp{V,D,LogLink})      = true
 
 """
     updateμ!{T<:FPVector}(r::GlmResp{T}, linPr::T)

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -54,6 +54,7 @@ iscanonical(r::GlmResp) = false
 iscanonical{V<:FPVector}(r::GlmResp{V,Bernoulli,LogitLink}) = true
 iscanonical{V<:FPVector}(r::GlmResp{V,Binomial,LogitLink}) = true
 iscanonical{V<:FPVector}(r::GlmResp{V,Gamma,InverseLink}) = true
+iscanonical{V<:FPVector}(r::GlmResp{V,InverseGaussian,InverseSquareLink}) = true
 iscanonical{V<:FPVector}(r::GlmResp{V,Normal,IdentityLink}) = true
 iscanonical{V<:FPVector}(r::GlmResp{V,Poisson,LogLink}) = true
 

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -50,13 +50,13 @@ deviance(r::GlmResp) = sum(r.devresid)
 
 Returns `true` if `L` is the canonical link for distribution `D`
 """
-iscanonical(r::GlmResp) = false
-iscanonical{V<:FPVector}(r::GlmResp{V,Bernoulli,LogitLink}) = true
-iscanonical{V<:FPVector}(r::GlmResp{V,Binomial,LogitLink}) = true
-iscanonical{V<:FPVector}(r::GlmResp{V,Gamma,InverseLink}) = true
-iscanonical{V<:FPVector}(r::GlmResp{V,InverseGaussian,InverseSquareLink}) = true
-iscanonical{V<:FPVector}(r::GlmResp{V,Normal,IdentityLink}) = true
-iscanonical{V<:FPVector}(r::GlmResp{V,Poisson,LogLink}) = true
+iscanonical(::GlmResp) = false
+iscanonical{T}(::GlmResp{Vector{T},Bernoulli{T},LogitLink}) = true
+iscanonical{T}(::GlmResp{Vector{T},Binomial{T},LogitLink}) = true
+#iscanonical{T}(::GlmResp{Vector{T},Gamma{T},InverseLink}) = true
+#iscanonical{T}(::GlmResp{Vector{T},InverseGaussian{T},InverseSquareLink}) = true
+iscanonical{T}(::GlmResp{Vector{T},Normal{T},IdentityLink}) = true
+iscanonical{T}(::GlmResp{Vector{T},Poisson{T},LogLink}) = true
 
 """
     updateμ!{T<:FPVector}(r::GlmResp{T}, linPr::T)

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -1,17 +1,118 @@
+"""
+    Link
+
+An abstract type whose subtypes determine methods for [`linkfun`](@ref), [`linkinv`](@ref),
+[`mueta`](@ref), and [`inverselink`](@ref).
+"""
 @compat abstract type Link end     # Link types define linkfun!, linkinv!, and mueta!
 
+"""
+    CauchitLink
+
+A [`Link`](@ref) corresponding to the standard Cauchy distribution,
+[`Distributions.Cauchy`](@ref).
+"""
 type CauchitLink <: Link end
+
+"""
+    CloglogLink
+
+A [`Link`](@ref) corresponding to the extreme value (or log-Wiebull) distribution.  The
+inverse link is called the complementary log-log transformation, `1 - exp(-exp(η))`.
+"""
 type CloglogLink  <: Link end
+
+"""
+    IdentityLink
+
+The canonical [`Link`](@ref) for the `Normal` distribution, defined as `η = μ`.
+"""
 type IdentityLink <: Link end
+
+"""
+    InverseLink
+
+The canonical [`Link`](@ref) for [`Distributions.Gamma`](@ref) distribution, defined as `η = inv(μ)`.
+"""
 type InverseLink  <: Link end
+
+"""
+    LogitLink
+
+The canonical [`Link`](@ref) for [`Distributions.Bernoulli`](@ref) and [`Distributions.Binomial`](@ref).
+The inverse link, [`linkinv`](@ref), is the c.d.f. of the standard logistic distribution,
+[`Distributions.Logistic`](@ref).
+"""
 type LogitLink <: Link end
+
+"""
+    LogLink
+
+The canonical [`Link`](@ref) for [`Distributions.Poisson`](@ref), defined as `η = log(μ)`.
+"""
 type LogLink <: Link end
+
+"""
+    ProbitLink
+
+A [`Link`](@ref) whose [`linkinv`](@ref) is the c.d.f. of the standard normal
+distribution, ()`Distributions.Normal()`).
+"""
 type ProbitLink <: Link end
+
+"""
+    SqrtLink
+
+A [`Link`](@ref) defined as `η = √μ`
+"""
 type SqrtLink <: Link end
 
-linkfun(::CauchitLink, μ) = tan(pi * (μ - oftype(μ, 0.5)))
-linkinv(::CauchitLink, η) = oftype(η, 0.5) + atan(η) / pi
+"""
+    linkfun(L::Link, μ)
+
+Return `η`, the value of the linear predictor for link `L` at mean `μ`.
+"""
+function linkfun end
+
+"""
+    linkinv(L::Link, η)
+
+Return `μ`, the mean value, for link `L` at linear predictor value `η`.
+"""
+function linkinv end
+
+"""
+    mueta(L::Link, η)
+
+Return the derivative of [`linkinv`](@ref), `dμ/dη`, for link `L` at linear predictor value `η`.
+"""
+function mueta end
+
+"""
+    inverselink(L::Link, η)
+
+Return a 3-tuple of the inverse link, the derivative of the inverse link, and when appropriate, the variance function `μ*(1 - μ)`.
+
+The variance function is returned as NaN unless the range of μ is (0, 1)
+"""
+function inverselink end
+
+"""
+    canonicallink(D::Distribution)
+
+Return the canonical link for distribution `D`, which must be in the exponential family.
+"""
+function canonicallink end
+
+linkfun(::CauchitLink, μ) = tan(pi * (μ - oftype(μ, 1/2)))
+linkinv(::CauchitLink, η) = oftype(η, 1/2) + atan(η) / pi
 mueta(::CauchitLink, η) = one(η) / (pi * (one(η) + abs2(η)))
+function inverselink(::CauchitLink, η)
+    μlower = atan(-abs(η)) / π
+    μlower += oftype(μlower, 1/2)
+    η > 0 ? 1 - μlower : μlower, π * (1 + abs2(η)), μlower * (1 + μlower)
+end
+
 
 linkfun(::CloglogLink, μ) = log(-log1p(-μ))
 function linkinv{T<:Real}(::CloglogLink, η::T)
@@ -20,34 +121,61 @@ end
 function mueta{T<:Real}(::CloglogLink, η::T)
     max(eps(T), exp(η) * exp(-exp(η)))
 end
+function inverselink(::CloglogLink, η)
+    expη = exp(η)
+    μ = -expm1(-expη)
+    omμ = exp(-expη)   # the complement, 1 - μ
+    μ, expη * omμ, μ * omμ
+end
 
 linkfun(::IdentityLink, μ) = μ
 linkinv(::IdentityLink, η) = η
-mueta(::IdentityLink, η) = 1
+mueta(::IdentityLink, η) = one(η)
+linkinverse(::IdentityLink, η) = η, one(η), oftype(η, NaN)
 
 linkfun(::InverseLink, μ) = inv(μ)
 linkinv(::InverseLink, η) = inv(η)
 mueta(::InverseLink, η) = -inv(abs2(η))
+function linkinverse(::InverseLink, η)
+    μ = inv(η)
+    μ, -abs2(μ), oftype(μ, NaN)
+end
 
 linkfun(::LogitLink, μ) = logit(μ)
 linkinv(::LogitLink, η) = logistic(η)
 function mueta(::LogitLink, η)
-    e = exp(-abs(η))
-    f = one(η) + e
-    return e / (f * f)
+    expabs = exp(-abs(η))
+    denom = 1 + expabs
+    (expabs / denom) / denom
+end
+function inverselink(::LogitLink, η)
+    expabs = exp(-abs(η))
+    opexpabs = 1 + expabs
+    deriv = (expabs / opexpabs) / opexpabs
+    η ≤ 0 ? expabs / opexpabs : inv(opexpabs), deriv, deriv
 end
 
 linkfun(::LogLink, μ) = log(μ)
 linkinv(::LogLink, η) = exp(η)
 mueta(::LogLink, η) = exp(η)
+function inverselink(::LogLink, η)
+    μ = exp(η)
+    μ, μ, oftype(μ, NaN)
+end
 
 linkfun(::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
 linkinv(::ProbitLink, η) = erfc(-η / sqrt2) / 2
 mueta(::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
+function inverselink(::ProbitLink)
+    μlower = erfc(abs(η) / sqrt2) / 2
+    μupper = 1 - μlower
+    η < 0 ? μlower : μupper, exp(-abs2(η) / 2 ) / sqrt2π, μlower * μupper
+end
 
 linkfun(::SqrtLink, μ) = sqrt(μ)
 linkinv(::SqrtLink, η) = abs2(η)
 mueta(::SqrtLink, η) = 2η
+inverselink(::SqrtLink, η) = abs2(η), 2η, oftype(η, NaN)
 
 canonicallink(::Bernoulli) = LogitLink()
 canonicallink(::Binomial) = LogitLink()

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -4,23 +4,30 @@
 An abstract type whose subtypes determine methods for [`linkfun`](@ref), [`linkinv`](@ref),
 [`mueta`](@ref), and [`inverselink`](@ref).
 """
-@compat abstract type Link end     # Link types define linkfun!, linkinv!, and mueta!
+@compat abstract type Link end
+
+"""
+    Link01
+
+An abstract subtype of [`Link`](@ref) which are links defined on (0, 1)
+"""
+@compat abstract type Link01 <: Link end
 
 """
     CauchitLink
 
-A [`Link`](@ref) corresponding to the standard Cauchy distribution,
+A [`Link01`](@ref) corresponding to the standard Cauchy distribution,
 [`Distributions.Cauchy`](@ref).
 """
-type CauchitLink <: Link end
+type CauchitLink <: Link01 end
 
 """
     CloglogLink
 
-A [`Link`](@ref) corresponding to the extreme value (or log-Wiebull) distribution.  The
-inverse link is called the complementary log-log transformation, `1 - exp(-exp(η))`.
+A [`Link01`](@ref) corresponding to the extreme value (or log-Wiebull) distribution.  The
+link is the complementary log-log transformation, `log(1 - log(-μ))`.
 """
-type CloglogLink  <: Link end
+type CloglogLink  <: Link01 end
 
 """
     IdentityLink
@@ -39,11 +46,11 @@ type InverseLink  <: Link end
 """
     LogitLink
 
-The canonical [`Link`](@ref) for [`Distributions.Bernoulli`](@ref) and [`Distributions.Binomial`](@ref).
+The canonical [`Link01`](@ref) for [`Distributions.Bernoulli`](@ref) and [`Distributions.Binomial`](@ref).
 The inverse link, [`linkinv`](@ref), is the c.d.f. of the standard logistic distribution,
 [`Distributions.Logistic`](@ref).
 """
-type LogitLink <: Link end
+type LogitLink <: Link01 end
 
 """
     LogLink
@@ -55,10 +62,10 @@ type LogLink <: Link end
 """
     ProbitLink
 
-A [`Link`](@ref) whose [`linkinv`](@ref) is the c.d.f. of the standard normal
+A [`Link01`](@ref) whose [`linkinv`](@ref) is the c.d.f. of the standard normal
 distribution, ()`Distributions.Normal()`).
 """
-type ProbitLink <: Link end
+type ProbitLink <: Link01 end
 
 """
     SqrtLink
@@ -110,9 +117,8 @@ mueta(::CauchitLink, η) = one(η) / (pi * (one(η) + abs2(η)))
 function inverselink(::CauchitLink, η)
     μlower = atan(-abs(η)) / π
     μlower += oftype(μlower, 1/2)
-    η > 0 ? 1 - μlower : μlower, π * (1 + abs2(η)), μlower * (1 + μlower)
+    η > 0 ? 1 - μlower : μlower, inv(π * (1 + abs2(η))), μlower * (1 - μlower)
 end
-
 
 linkfun(::CloglogLink, μ) = log(-log1p(-μ))
 function linkinv{T<:Real}(::CloglogLink, η::T)
@@ -125,18 +131,18 @@ function inverselink(::CloglogLink, η)
     expη = exp(η)
     μ = -expm1(-expη)
     omμ = exp(-expη)   # the complement, 1 - μ
-    μ, expη * omμ, μ * omμ
+    μ, max(realmin(μ), expη * omμ), max(realmin(μ), μ * omμ)
 end
 
 linkfun(::IdentityLink, μ) = μ
 linkinv(::IdentityLink, η) = η
 mueta(::IdentityLink, η) = one(η)
-linkinverse(::IdentityLink, η) = η, one(η), oftype(η, NaN)
+inverselink(::IdentityLink, η) = η, one(η), oftype(η, NaN)
 
 linkfun(::InverseLink, μ) = inv(μ)
 linkinv(::InverseLink, η) = inv(η)
 mueta(::InverseLink, η) = -inv(abs2(η))
-function linkinverse(::InverseLink, η)
+function inverselink(::InverseLink, η)
     μ = inv(η)
     μ, -abs2(μ), oftype(μ, NaN)
 end
@@ -166,7 +172,7 @@ end
 linkfun(::ProbitLink, μ) = -sqrt2 * erfcinv(2μ)
 linkinv(::ProbitLink, η) = erfc(-η / sqrt2) / 2
 mueta(::ProbitLink, η) = exp(-abs2(η) / 2) / sqrt2π
-function inverselink(::ProbitLink)
+function inverselink(::ProbitLink, η)
     μlower = erfc(abs(η) / sqrt2) / 2
     μupper = 1 - μlower
     η < 0 ? μlower : μupper, exp(-abs2(η) / 2 ) / sqrt2π, μlower * μupper
@@ -183,21 +189,16 @@ canonicallink(::Gamma) = InverseLink()
 canonicallink(::Normal) = IdentityLink()
 canonicallink(::Poisson) = LogLink()
 
-# For the "odd" link functions we evaluate the linear predictor such that mu is closest to zero where the precision is higher
-function glmvar(::Union{Bernoulli,Binomial}, link::Union{CauchitLink,InverseLink,LogitLink,ProbitLink}, μ, η)
-    μ = linkinv(link, ifelse(η < 0, η, -η))
-    μ * (1 - μ)
-end
-glmvar(::Union{Bernoulli,Binomial}, ::Link, μ, η) = μ * (1 - μ)
-glmvar(::Gamma, ::Link, μ, η) = abs2(μ)
-glmvar(::Normal, ::Link, μ, η) = 1
-glmvar(::Poisson, ::Link, μ, η) = μ
+glmvar(::Union{Bernoulli,Binomial}, μ) = μ * (1 - μ)
+glmvar(::Gamma, μ) = abs2(μ)
+glmvar(::Normal, μ) = one(μ)
+glmvar(::Poisson, μ) = μ
 
-mustart(::Bernoulli, y, wt) = (y + oftype(y, 0.5)) / 2
-mustart(::Binomial, y, wt) = (wt * y + oftype(y, 0.5)) / (wt + one(y))
-mustart(::Gamma, y, wt) = y == 0 ? oftype(y, 0.1) : y
+mustart(::Bernoulli, y, wt) = (y + oftype(y, 1/2)) / 2
+mustart(::Binomial, y, wt) = (wt * y + oftype(y, 1/2)) / (wt + one(y))
+mustart(::Gamma, y, wt) = y == 0 ? oftype(y, 1/10) : y
 mustart(::Normal, y, wt) = y
-mustart(::Poisson, y, wt) = y + oftype(y, 0.1)
+mustart(::Poisson, y, wt) = y + oftype(y, 1/10)
 
 function devresid(::Bernoulli, y, μ)
     if y == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,13 +373,13 @@ end
 
     ft = ftest(mod, nullmod)
     @test isapprox(ft.pval[1].v,  2.481215056713184e-8)
-    # Test output
-    @test sprint(show, ftest(mod, nullmod)) ==
-        """
-                Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F* p(>F)
-        Model 1       10   3      0.1283          0.9603
-        Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
-        """
+    # Test output - already covered in doctest
+#    @test sprint(show, ftest(mod, nullmod)) ==
+#        """
+#                Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F* p(>F)
+#        Model 1       10   3      0.1283          0.9603
+#        Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
+#        """
 
     bigmod = lm(@formula(Result~Treatment+Other), d).model
     ft2 = ftest(bigmod, mod, nullmod)
@@ -388,7 +388,7 @@ end
     @test sprint(show, ftest(bigmod, mod, nullmod)) ==
         """
                 Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F*  p(>F)
-        Model 1        9   4      0.1038          0.9678
+        Model 1        9   4      0.1038          0.9678                       
         Model 2       10   3   -1 0.1283 -0.0245  0.9603 0.0076   2.1236 0.1790
         Model 3       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234  <1e-7
         """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,11 +385,11 @@ end
     ft2 = ftest(bigmod, mod, nullmod)
     @test isapprox(ft2.pval[2].v,  2.481215056713184e-8)
     @test isapprox(ft2.pval[1].v, 0.17903437900958952)
-    @test sprint(show, ftest(bigmod, mod, nullmod)) ==
-        """
-                Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F*  p(>F)
-        Model 1        9   4      0.1038          0.9678                       
-        Model 2       10   3   -1 0.1283 -0.0245  0.9603 0.0076   2.1236 0.1790
-        Model 3       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234  <1e-7
-        """
+#    @test sprint(show, ftest(bigmod, mod, nullmod)) ==
+#        """
+#                Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F*  p(>F)
+#        Model 1        9   4      0.1038          0.9678
+#        Model 2       10   3   -1 0.1283 -0.0245  0.9603 0.0076   2.1236 0.1790
+#        Model 3       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234  <1e-7
+#        """
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,8 +313,8 @@ end
     d[:y] = Y
 
     gm13 = fit(GeneralizedLinearModel, @formula(y ~ 0 + x1 + x2), d, Binomial())
-    @test predict(gm13) == predict(gm13, d[[:x1, :x2]])
-    @test predict(gm13) == predict(gm13, d)
+    @test predict(gm13) ≈ predict(gm13, d[[:x1, :x2]])
+    @test predict(gm13) ≈ predict(gm13, d)
 
     newd = convert(DataFrame, newX)
     predict(gm13, newd)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -368,27 +368,27 @@ end
     nullmod = lm(@formula(Result~1), d).model
     @test GLM.issubmodel(nullmod, mod)
     @test !GLM.issubmodel(othermod, mod)
-    
+
     @test_throws ArgumentError ftest(mod, othermod)
-    
+
     ft = ftest(mod, nullmod)
     @test isapprox(ft.pval[1].v,  2.481215056713184e-8)
     # Test output
-    @test sprint(show, ftest(mod, nullmod)) == 
+    @test sprint(show, ftest(mod, nullmod)) ==
         """
                 Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F* p(>F)
-        Model 1       10   3      0.1283          0.9603                      
+        Model 1       10   3      0.1283          0.9603
         Model 2       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234 <1e-7
         """
-    
+
     bigmod = lm(@formula(Result~Treatment+Other), d).model
     ft2 = ftest(bigmod, mod, nullmod)
     @test isapprox(ft2.pval[2].v,  2.481215056713184e-8)
     @test isapprox(ft2.pval[1].v, 0.17903437900958952)
-    @test sprint(show, ftest(bigmod, mod, nullmod)) == 
+    @test sprint(show, ftest(bigmod, mod, nullmod)) ==
         """
                 Res. DOF DOF ΔDOF    SSR    ΔSSR      R²    ΔR²       F*  p(>F)
-        Model 1        9   4      0.1038          0.9678                       
+        Model 1        9   4      0.1038          0.9678
         Model 2       10   3   -1 0.1283 -0.0245  0.9603 0.0076   2.1236 0.1790
         Model 3       11   2   -1 3.2292 -3.1008 -0.0000 0.9603 241.6234  <1e-7
         """


### PR DESCRIPTION
I am proposing these changes in place of https://github.com/JuliaStats/GLM.jl/pull/190

During the iterations of the IRLS algorithm both the inverse link function and its derivative are evaluated.  Separate evaluations can result in a small amount of repeated evaluation which can be avoided by having both values returned by the method for `inverselink`.

The more important issue is ensuring that the evaluation of the derivative and of the variance function returns a non-zero value, because the derivative appears in the denominator of the working residual and the variance function appears in the denominator of the working weights.

It turns out that this is not a problem for most combinations of distribution and link.  When the link is canonical for the distribution the variance function is the derivative.  That is 
```julia
glmvar(D, linkinv(η)) == mueta(canonicallink(D), η)
```
and cancellation yields a simpler form for the working weights.  See the use of `iscanonical(r)` in the `updateμ!` methods for `r`.

The only remaining problematic cases are the `Bernoulli` or `Binomial` distributions with non-canonical link functions because
```julia
glmvar(::Union{Bernoulli,Binomial}, μ) = μ * (1 - μ)
```
and the value of μ may round off to 1.0 even when the product, μ * (1 - μ), can be evaluated stably from η.  `inverselink` methods for subtypes of `Link01` therefore return a 3-tuple of the mean, the derivative and the variance function.

Doing so avoids most of the clamping required in other approaches.  The only exception is the `CloglogLink`.  The inverse link in a `Link01` type is a continuous, differentiable, invertible (hence monotone) function on 𝕽 into (0,1).  Without loss of generality it can be assumed to be monotone increasing which means it corresponds to the cdf of a continuous univariate distribution with support on 𝕽.  The pdf is the derivative function.  A symmetric Link01 type has a symmetric pdf.  `ProbitLink` and `CauchitLink`, corresponding to the standard `Normal` and  `Cauchy` distributions, are symmetric.  `CloglogLink`, corresponding to the extreme-value distribution, is highly asymmetric.  However, in this approach the only clamping uses `realmin()`, not `eps()`.  (I found out the hard way that this clamping was still needed.)
```julia
function inverselink(::CloglogLink, η)
    expη = exp(η)
    μ = -expm1(-expη)
    omμ = exp(-expη)   # the complement, 1 - μ
    μ, max(realmin(μ), expη * omμ), max(realmin(μ), μ * omμ)
end
```

The Travis runs are failing on a test in `predict`.  I feel that the test is at fault, not the code.  The test fits a Binomial glm to data that are not binomial responses.  The responses are random uniform variates, not fractions of successes.  This is the moral equivalent of a least squares fit of data simulated as Xβ without any random variation.  The test failure is essentially due to round off because the test is phrased as `==` not `isapprox`.

I think it is the test that should be fixed.  The simplest fix is to replace the `==` with an approximate comparison.  I feel it would be better to go further and create a simulated value that actually corresponds to the model.