### PR TITLE
Typo in `issubmodel`

### DIFF
--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -15,7 +15,7 @@ function issubmodel(mod1::LinPredModel, mod2::LinPredModel)
     pred1 = mod1.pp.X
     npreds1 = size(pred1, 2)
     pred2 = mod2.pp.X
-    npreds2 = size(pred1, 2)
+    npreds2 = size(pred2, 2)
     # If model 1 has more predictors, it can't possibly be a submodel
     npreds1 > npreds2 && return false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -397,8 +397,11 @@ end
     mod = lm(@formula(Result~Treatment), d).model
     othermod = lm(@formula(Result~Other), d).model
     nullmod = lm(@formula(Result~1), d).model
+    bothmod = lm(@formula(Result~Other+Treatment), d).model
     @test GLM.issubmodel(nullmod, mod)
     @test !GLM.issubmodel(othermod, mod)
+    @test GLM.issubmodel(mod, bothmod)
+    @test GLM.issubmodel(othermod, bothmod)
 
     @test_throws ArgumentError ftest(mod, othermod)
 


### PR DESCRIPTION
Fix a typo in `issubmodel` that lead to unexpected behavior.

The added test can work as a MWE: it fails with the current version of GLM, but passes after the commit.

See #195.