### PR TITLE
use macro to construct formula in test for StatsModels v0.2.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ Compat 0.33.0
 Distributions 0.10.0
 StatsBase 0.22.0
 StatsFuns 0.3.0
-StatsModels 0.2.0 0.2.4
+StatsModels 0.2.0
 SpecialFunctions 0.1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,8 @@ end
     dfrm = DataFrame([categorical(repeat(string.('A':'D'), inner = 6)),
                      categorical(repeat(string.('a':'c'), inner = 2, outer = 4))],
                      [:G, :H])
-    X = ModelMatrix(ModelFrame(Formula(nothing, :(1+G*H)), dfrm)).m
+    f = @eval(@formula($nothing ~ 1+G*H))
+    X = ModelMatrix(ModelFrame(f, dfrm)).m
     y = X * (1:size(X, 2)) + 0.1 * randn(MersenneTwister(1234321), size(X, 1))
     inds = deleteat!(collect(1:length(y)), 7:8)
     m1 = fit(LinearModel, X, y)


### PR DESCRIPTION
Fix deprecated 2-argument `Formula` constructor in StatsModels.jl v0.2.4