### PR TITLE
Change StatsBase.stderr to StatsBase.stderror and bump StatsBase requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
-- `stderr`: standard errors of the coefficients
+- `stderror`: standard errors of the coefficients
 - `vcov`: estimated variance-covariance matrix of the coefficient estimates
 - `predict` : obtain predicted values of the dependent variable from the fitted model
 
@@ -57,7 +57,7 @@ Coefficients:
 (Intercept)  -0.666667   0.62361 -1.06904   0.2850
 X                  2.5  0.288675  8.66025   <1e-17
 
-julia> stderr(OLS)
+julia> stderror(OLS)
 2-element Array{Float64,1}:
  0.62361
  0.288675

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
 Compat 0.33.0
 Distributions 0.10.0
-StatsBase 0.12.0
+StatsBase 0.22.0
 StatsFuns 0.3.0
-StatsModels 0.2.0
+StatsModels 0.2.0 0.2.4
 SpecialFunctions 0.1.0

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -13,12 +13,12 @@ module GLM
 
     import Base: (\), cholfact, convert, cor, show, size
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
-                      loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict,
+                      loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
                       fit, model_response, r2, r², adjr2, adjr², PValue
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
-           loglikelihood, nullloglikelihood, nobs, stderr, vcov, residuals, predict, 
+           loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fit, fit!, model_response, r2, r², adjr2, adjr²
 
     export                              # types

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -130,7 +130,7 @@ end
 
 function coeftable(mm::AbstractGLM)
     cc = coef(mm)
-    se = stderr(mm)
+    se = stderror(mm)
     zz = cc ./ se
     CoefTable(hcat(cc,se,zz,2.0 * ccdf.(Normal(), abs.(zz))),
               ["Estimate","Std.Error","z value", "Pr(>|z|)"],
@@ -138,7 +138,7 @@ function coeftable(mm::AbstractGLM)
 end
 
 function confint(obj::AbstractGLM, level::Real)
-    hcat(coef(obj),coef(obj)) + stderr(obj)*quantile(Normal(),(1. -level)/2.)*[1. -1.]
+    hcat(coef(obj),coef(obj)) + stderror(obj)*quantile(Normal(),(1. -level)/2.)*[1. -1.]
 end
 confint(obj::AbstractGLM) = confint(obj, 0.95)
 

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -227,7 +227,7 @@ function cor(x::LinPredModel)
     scale!(invstd, scale!(Σ, invstd))
 end
 
-stderr(x::LinPredModel) = sqrt.(diag(vcov(x)))
+stderror(x::LinPredModel) = sqrt.(diag(vcov(x)))
 
 function show(io::IO, obj::LinPredModel)
     println(io, "$(typeof(obj)):\n\nCoefficients:\n", coeftable(obj))

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -183,7 +183,7 @@ end
 
 function coeftable(mm::LinearModel)
     cc = coef(mm)
-    se = stderr(mm)
+    se = stderror(mm)
     tt = cc ./ se
     CoefTable(hcat(cc,se,tt,ccdf.(FDist(1, dof_residual(mm)), abs2.(tt))),
               ["Estimate","Std.Error","t value", "Pr(>|t|)"],
@@ -215,7 +215,7 @@ end
 
 
 function confint(obj::LinearModel, level::Real)
-    hcat(coef(obj),coef(obj)) + stderr(obj) *
+    hcat(coef(obj),coef(obj)) + stderror(obj) *
     quantile(TDist(dof_residual(obj)), (1. - level)/2.) * [1. -1.]
 end
 confint(obj::LinearModel) = confint(obj, 0.95)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,7 +158,7 @@ anorexia = CSV.read(joinpath(glm_datadir, "anorexia.csv"))
 
 @testset "Offset" begin
     gm6 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
-              Normal(), IdentityLink(), offset=Array(anorexia[:Prewt]))
+              Normal(), IdentityLink(), offset=Array{Float64}(anorexia[:Prewt]))
     @test GLM.cancancel(gm6.model.rr)
     test_show(gm6)
     @test dof(gm6) == 5
@@ -170,20 +170,20 @@ anorexia = CSV.read(joinpath(glm_datadir, "anorexia.csv"))
     @test isapprox(coef(gm6),
         [45.674043486911685, -0.5655388496390964, 4.097065528072901, 8.660128180991693])
     @test isapprox(GLM.dispersion(gm6.model, true), 48.6950385282296)
-    @test isapprox(stderr(gm6),
+    @test isapprox(stderror(gm6),
         [13.21670540145523, 0.16118236185182783, 1.893492606966926, 2.1931494116430517])
 end
 
 @testset "Normal LogLink offset" begin
     gm7 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
-              Normal(), LogLink(), offset=Array(anorexia[:Prewt]), convTol=1e-8)
+              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), convTol=1e-8)
     @test !GLM.cancancel(gm7.model.rr)
     test_show(gm7)
     @test isapprox(deviance(gm7), 3265.207242977156)
     @test isapprox(coef(gm7),
         [3.9416285291318798, -0.9944526931311773, 0.050698258703983666, 0.1021922886616272])
     @test isapprox(GLM.dispersion(gm7.model, true), 48.017753573192266)
-    @test isapprox(stderr(gm7), 
+    @test isapprox(stderror(gm7),
         [0.1554026019351794, 0.0018862835443589627, 0.022584040191142126, 0.025187228659634627],
         atol=1e-6)
 end
@@ -205,7 +205,7 @@ clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
     @test isapprox(bic(gm8), 38.58159768156315)
     @test isapprox(coef(gm8), [-0.01655438172784895,0.01534311491072141])
     @test isapprox(GLM.dispersion(gm8.model, true), 0.002446059333495581, atol=1e-6)
-    @test isapprox(stderr(gm8), [0.00092754223, 0.000414957683], atol=1e-6)
+    @test isapprox(stderror(gm8), [0.00092754223, 0.000414957683], atol=1e-6)
 end
 
 @testset "InverseGaussian" begin
@@ -221,7 +221,7 @@ end
     @test isapprox(bic(gm8a), 62.16652574970839)
     @test isapprox(coef(gm8a), [-0.0011079770504295668,0.0007219138982289362])
     @test isapprox(GLM.dispersion(gm8a.model, true), 0.0011008719709455776, atol=1e-6)
-    @test isapprox(stderr(gm8a), [0.0001675339726910311,9.468485015919463e-5], atol=1e-6)
+    @test isapprox(stderror(gm8a), [0.0001675339726910311,9.468485015919463e-5], atol=1e-6)
 end
 
 @testset "Gamma LogLink" begin
@@ -237,7 +237,7 @@ end
     @test isapprox(bic(gm9), 59.07332993970688)
     @test isapprox(coef(gm9), [5.50322528458221, -0.60191617825971])
     @test isapprox(GLM.dispersion(gm9.model, true), 0.02435442293561081)
-    @test isapprox(stderr(gm9), [0.19030107482720, 0.05530784660144])
+    @test isapprox(stderror(gm9), [0.19030107482720, 0.05530784660144])
 end
 
 @testset "Gamma IdentityLink" begin
@@ -253,7 +253,7 @@ end
     @test isapprox(bic(gm10), 71.02381860657701)
     @test isapprox(coef(gm10), [99.250446880986, -18.374324929002])
     @test isapprox(GLM.dispersion(gm10.model, true), 0.10417373, atol=1e-6)
-    @test isapprox(stderr(gm10), [17.864084, 4.297895], atol=1e-4)
+    @test isapprox(stderror(gm10), [17.864084, 4.297895], atol=1e-4)
 end
 
 # Logistic regression using aggregated data and weights


### PR DESCRIPTION
Tighten type for offset vectors in tests to avoid Missing types

Upper bound StatsModels to 0.2.4