### PR TITLE
Don't export as much

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -19,59 +19,45 @@ module GLM
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fit, fit!, model_response, r2, r², adjr2, adjr²
 
-    export                              # types
+    export
+        # types
+        ## Distributions
         Bernoulli,
         Binomial,
-        CauchitLink,
-        CloglogLink,
-        DensePred,
-        DensePredQR,
-        DensePredChol,
         Gamma,
         Gaussian,
-        GeneralizedLinearModel,
-        GlmResp,
-        IdentityLink,
         InverseGaussian,
-        InverseLink,
-        InverseSquareLink,
-        LinearModel,
-        Link,
-        LinPred,
-        LinPredModel,
-        LogitLink,
-        LogLink,
-        LmResp,
         NegativeBinomial,
-        NegativeBinomialLink,
         Normal,
         Poisson,
+
+        ## Link types
+        CauchitLink,
+        CloglogLink,
+        IdentityLink,
+        InverseLink,
+        InverseSquareLink,
+        LogitLink,
+        LogLink,
+        NegativeBinomialLink,
         ProbitLink,
         SqrtLink,
 
-                                        # functions
+        # Model types
+        GeneralizedLinearModel,
+        LinearModel,
+
+        # functions
         canonicallink,  # canonical link function for a distribution
-        delbeta!,       # evaluate the increment in the coefficient vector
         deviance,       # deviance of fitted and observed responses
         devresid,       # vector of squared deviance residuals
         formula,        # extract the formula from a model
         glm,            # general interface
-        glmvar,         # the variance function
-        inverselink,    # returns μ, dμ/dη and, when appropriate, μ*(1-μ)
-        linkfun,        # link function mapping mu to eta, the linear predictor
-        linkinv,        # inverse link mapping eta to mu
         linpred,        # linear predictor
-        linpred!,       # update the linear predictor in place
         lm,             # linear model
-        logistic,
-        logit,
-        mueta,          # derivative of inverse link
-        mustart,        # derive starting values for the mu vector
         negbin,         # interface to fitting genative binomial regression
         nobs,           # total number of observations
         predict,        # make predictions
-        updateμ!,       # update the response type from the linear predictor
-        wrkresp,        # working response
         ftest           # compare models with an F test
 
     const FP = AbstractFloat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using CategoricalArrays, CSV, DataFrames, LinearAlgebra, SparseArrays, Random,
       Statistics, StatsBase, Test, RDatasets
 using GLM
+using StatsFuns: logistic
 
 test_show(x) = show(IOBuffer(), x)
 
@@ -205,7 +206,7 @@ clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
 @testset "Gamma" begin
     gm8 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma())
     @test !GLM.cancancel(gm8.model.rr)
-    @test isa(Link(gm8.model), InverseLink)
+    @test isa(GLM.Link(gm8.model), InverseLink)
     test_show(gm8)
     @test dof(gm8) == 3
     @test isapprox(deviance(gm8), 0.016729715178484157)
@@ -221,7 +222,7 @@ end
 @testset "InverseGaussian" begin
     gm8a = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, InverseGaussian())
     @test !GLM.cancancel(gm8a.model.rr)
-    @test isa(Link(gm8a.model), InverseSquareLink)
+    @test isa(GLM.Link(gm8a.model), InverseSquareLink)
     test_show(gm8a)
     @test dof(gm8a) == 3
     @test isapprox(deviance(gm8a), 0.006931128347234519)
@@ -567,7 +568,7 @@ end
 
 @testset "Issue 153" begin
     X = [ones(10) randn(10)]
-    Test.@inferred cholesky(DensePredQR{Float64}(X))
+    Test.@inferred cholesky(GLM.DensePredQR{Float64}(X))
 end
 
 @testset "Issue 224" begin
@@ -575,7 +576,7 @@ end
     # Make X slightly ill conditioned to amplify rounding errors
     X = Matrix(qr(randn(100,5)).Q)*Diagonal(10 .^ (-2.0:1.0:2.0))*Matrix(qr(randn(5,5)).Q)'
     y = randn(100)
-    @test coef(GLM.glm(X, y, GLM.Normal(), GLM.IdentityLink())) ≈ coef(lm(X, y))
+    @test coef(glm(X, y, Normal(), IdentityLink())) ≈ coef(lm(X, y))
 end
 
 @testset "Issue #228" begin


### PR DESCRIPTION
Currently, we export quite a few functions and types. I think most of them aren't relevant to most users so I'm suggesting that they are no longer exported. In this version, I haven't unexported `canonicallink`, `devresid`, and `linpred` but I think we could consider unexporting them as well. Thoughts?