### PR TITLE
Using dof approach to proper allowrankdeficient values

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -253,4 +253,4 @@ end
 coef(x::LinPred) = x.beta0
 coef(obj::LinPredModel) = coef(obj.pp)
 
-dof_residual(obj::LinPredModel) = nobs(obj) - length(coef(obj))
+dof_residual(obj::LinPredModel) = nobs(obj) - dof(obj) + 1

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -147,6 +147,8 @@ lm(X, y, allowrankdeficient::Bool=false) = fit(LinearModel, X, y, allowrankdefic
 
 dof(x::LinearModel) = length(coef(x)) + 1
 
+dof(obj::LinearModel{<:LmResp,<:DensePredChol{<:Real,<:CholeskyPivoted}}) = obj.pp.chol.rank + 1
+
 """
     deviance(obj::LinearModel)
 
@@ -208,9 +210,6 @@ function predict(mm::LinearModel, newx::AbstractMatrix, interval_type::Symbol, l
     interval = quantile(TDist(dof_residual(mm)), (1 - level)/2) * sqrt.(retvariance)
     hcat(retmean, retmean .+ interval, retmean .- interval)
 end
-
-dof_residual(obj::LinearModel{<:Any,<:DensePredChol{<:Any,<:CholeskyPivoted}}) =
-    nobs(obj) - obj.pp.chol.rank
 
 function confint(obj::LinearModel, level::Real)
     hcat(coef(obj),coef(obj)) + stderror(obj) *

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -574,9 +574,14 @@ end
 end
 
 @testset "Issue #263" begin
-    data = DataFrame(y = rand(100), x = rand(100))
-    data.x2 = data.x
-    model1 = lm(@formula(y ~ x), data)
-    model2 = lm(@formula(y ~ x + x2), data, true)
+    data = dataset("datasets", "iris")
+    data.SepalWidth2 = data.SepalWidth
+    model1 = lm(@formula(SepalLength ~ SepalWidth), data)
+    model2 = lm(@formula(SepalLength ~ SepalWidth + SepalWidth2), data, true)
+    model3 = lm(@formula(SepalLength ~ 0 + SepalWidth), data)
+    model4 = lm(@formula(SepalLength ~ 0 + SepalWidth + SepalWidth2), data, true)
+    @test dof(model1) == dof(model2)
+    @test dof(model3) == dof(model4)
     @test dof_residual(model1) == dof_residual(model2)
+    @test dof_residual(model3) == dof_residual(model4)
 end


### PR DESCRIPTION
This PR fixes the `dof` for `allowrankdeficient` models and also `dof_residual` through the use of `dof`.