### PR TITLE
update statsbase API

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,12 +12,12 @@ module GLM
     import Statistics: cor
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
                       loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-                      fit, model_response, r2, r², adjr2, adjr², PValue
+                      fit, response, modelmatrix, r2, r², adjr2, adjr², PValue
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv, digamma, trigamma
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-           fit, fit!, model_response, r2, r², adjr2, adjr²
+           fit, fit!, response, modelmatrix, r2, r², adjr2, adjr²
 
     export                              # types
         Bernoulli,

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,12 +12,12 @@ module GLM
     import Statistics: cor
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
                       loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-                      fit, response, modelmatrix, r2, r², adjr2, adjr², PValue
+                      fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv, digamma, trigamma
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-           fit, fit!, response, modelmatrix, r2, r², adjr2, adjr²
+           fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²
 
     export                              # types
         Bernoulli,

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -228,7 +228,7 @@ end
 
 modelframe(obj::LinPredModel) = obj.fr
 modelmatrix(obj::LinPredModel) = obj.pp.X
-model_response(obj::LinPredModel) = obj.rr.y
+response(obj::LinPredModel) = obj.rr.y
 
 fitted(m::LinPredModel) = m.rr.mu
 predict(mm::LinPredModel) = fitted(mm)


### PR DESCRIPTION
model_response -> response, import modelmatrix.

These are changes that landed almost a year ago in the StatsBase (JuliaStats/StatsBase.jl#321 and JuliaStats/StatsBase.jl#355).  We currently require a version of StatsBase that has all these changes (I think 0.21 is the earliest, and we're at 0.22).

There's a deprecation of `model_response` in favor of `response` in StatsBase; I didn't add one here because I figured that would cover it but I'm not sure.