### PR TITLE
Fix docstring for dispersion

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -337,7 +337,7 @@ Distributions.Distribution(m::GeneralizedLinearModel) = Distribution(m.rr)
     dispersion(m::AbstractGLM, sqr::Bool=false)
 
 Return the estimated dispersion (or scale) parameter for a model's distribution,
-generally written σ² for linear models and ϕ for generalized linear models.
+generally written σ for linear models and ϕ for generalized linear models.
 It is, by definition, equal to 1 for the Bernoulli, Binomial, and Poisson families.
 
 If `sqr` is `true`, the squared dispersion parameter is returned.


### PR DESCRIPTION
σ² is only returned when `sqr=true`.

Fixes https://github.com/JuliaStats/GLM.jl/issues/283.