### PR TITLE
Add basic documentation for `fit` and `glm`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,6 +46,12 @@ x1    0.717436  0.775175 0.925515   0.3818
 x2   -0.152062  0.124931 -1.21717   0.2582
 ```
 
+```@docs
+glm
+fit
+lm
+```
+
 ## Model methods
 ```@docs
 GLM.cancancel
@@ -56,7 +62,6 @@ GLM.installbeta!
 GLM.issubmodel
 linpred!
 linpred
-lm
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -304,7 +304,7 @@ Fit a generalized linear model to data.
 # Keyword Arguments
 - `verbose::Bool=false`: Display convergence information for each iteration
 - `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
-- `convTol::Real=1.e-6`: Convergence is achieved when the relative change in
+- `convTol::Real=1e-6`: Convergence is achieved when the relative change in
 deviance is less than this
 - `minStepFac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
 - `start=nothing`: Starting values for beta

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -299,9 +299,9 @@ end
 """
     fit(GeneralizedLinearModel, X, y, d, [l = canonicallink(d)]; <keyword arguments>)
 
-Fit a generalized linear model to data. `X` and `y` can either be a formula and
-a dataframe, respectively, or a matrix and a vector. `l` must be a
-[`Link`](@ref), if supplied.
+Fit a generalized linear model to data. `X` and `y` can either be a matrix and a
+vector, respectively, or a formula and a data frame. `d` must be a
+`UnivariateDistribution`, and `l` must be a [`Link`](@ref), if supplied.
 
 # Keyword Arguments
 - `verbose::Bool=false`: Display convergence information for each iteration

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -339,7 +339,7 @@ l::Link=canonicallink(d); kwargs...) where {M<:AbstractGLM} =
 """
     glm(F, D, args...; kwargs...)
 
-Fit a generalized linear model to data. Alias for fit(GeneralizedLinearModel, ...).
+Fit a generalized linear model to data. Alias for `fit(GeneralizedLinearModel, ...)`.
 See [`fit`](@ref) for documentation.
 """
 glm(F, D, args...; kwargs...) = fit(GeneralizedLinearModel, F, D, args...; kwargs...)

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -304,7 +304,9 @@ Fit a generalized linear model to data.
 # Keyword Arguments
 - `verbose::Bool=false`: Display convergence information for each iteration
 - `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
-- `convTol::Real=1.e-6`: Convergence is achieved when the relative change in deviance is less than this
+- `convTol::Real=1.e-6`: Convergence is achieved when the relative change in
+deviance is less than this
+- `minStepFac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
 - `start=nothing`: Starting values for beta
 """
 function fit(::Type{M},

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -297,9 +297,11 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
 end
 
 """
-    fit(AbstractGLM, X, y, d, [l = canonicallink(d)]; <keyword arguments>)
+    fit(GeneralizedLinearModel, X, y, d, [l = canonicallink(d)]; <keyword arguments>)
 
-Fit a generalized linear model to data.
+Fit a generalized linear model to data. `X` and `y` can either be a formula and
+a dataframe, respectively, or a matrix and a vector. `l` must be a
+[`Link`](@ref), if supplied.
 
 # Keyword Arguments
 - `verbose::Bool=false`: Display convergence information for each iteration
@@ -307,7 +309,8 @@ Fit a generalized linear model to data.
 - `convTol::Real=1e-6`: Convergence is achieved when the relative change in
 deviance is less than this
 - `minStepFac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
-- `start=nothing`: Starting values for beta
+- `start::AbstractVector=nothing`: Starting values for beta. Should have the
+same length as the number of columns in the model matrix.
 """
 function fit(::Type{M},
     X::Union{Matrix{T},SparseMatrixCSC{T}},

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -296,6 +296,17 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
     end
 end
 
+"""
+    fit(AbstractGLM, X, y, d, [l = canonicallink(d)]; <keyword arguments>)
+
+Fit a generalized linear model to data.
+
+# Keyword Arguments
+- `verbose::Bool=false`: Display convergence information for each iteration
+- `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
+- `convTol::Real=1.e-6`: Convergence is achieved when the relative change in deviance is less than this
+- `start=nothing`: Starting values for beta
+"""
 function fit(::Type{M},
     X::Union{Matrix{T},SparseMatrixCSC{T}},
     y::V,
@@ -323,6 +334,12 @@ d::UnivariateDistribution,
 l::Link=canonicallink(d); kwargs...) where {M<:AbstractGLM} =
     fit(M, float(X), float(y), d, l; kwargs...)
 
+"""
+    glm(F, D, args...; kwargs...)
+
+Fit a generalized linear model to data. Alias for fit(GeneralizedLinearModel, ...).
+See [`fit`](@ref) for documentation.
+"""
 glm(F, D, args...; kwargs...) = fit(GeneralizedLinearModel, F, D, args...; kwargs...)
 
 GLM.Link(mm::AbstractGLM) = mm.l


### PR DESCRIPTION
I was unable to find any documentation on how to fit a GLM to data, beyond a few
examples in the docs. I have added a small amount of documentation for how to
use `fit`, and added them to the Documenter markdown. I have also re-iterated
that `glm` is an alias for `fit`, which wasn't clear to me when I first started
using this package.