### PR TITLE
Rename keyword arguments to follow lower case convention

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -197,15 +197,15 @@ end
 
 dof(x::GeneralizedLinearModel) = dispersion_parameter(x.rr.d) ? length(coef(x)) + 1 : length(coef(x))
 
-function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real,
-              convTol::Real, start)
+function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real,
+               convtol::Real, start)
 
     # Return early if model has the fit flag set
     m.fit && return m
 
     # Check arguments
-    maxIter >= 1       || throw(ArgumentError("maxIter must be positive"))
-    0 < minStepFac < 1 || throw(ArgumentError("minStepFac must be in (0, 1)"))
+    maxiter >= 1       || throw(ArgumentError("maxiter must be positive"))
+    0 < minstepfac < 1 || throw(ArgumentError("minstepfac must be in (0, 1)"))
 
     # Extract fields and set convergence flag
     cvg, p, r = false, m.pp, m.rr
@@ -228,7 +228,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
     end
     devold = deviance(m)
 
-    for i = 1:maxIter
+    for i = 1:maxiter
         f = 1.0 # line search factor
         local dev
 
@@ -244,11 +244,11 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
 
         # Line search
         ## If the deviance isn't declining then half the step size
-        ## The convTol*dev term is to avoid failure when deviance
+        ## The convtol*dev term is to avoid failure when deviance
         ## is unchanged except for rouding errors.
-        while dev > devold + convTol*dev
+        while dev > devold + convtol*dev
             f /= 2
-            f > minStepFac || error("step-halving failed at beta0 = $(p.beta0)")
+            f > minstepfac || error("step-halving failed at beta0 = $(p.beta0)")
             try
                 updateμ!(r, linpred(p, f))
                 dev = deviance(m)
@@ -261,25 +261,58 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxIter::Integer, minStepFac::Real
         # Test for convergence
         crit = (devold - dev)/dev
         verbose && println("$i: $dev, $crit")
-        if crit < convTol || dev == 0
+        if crit < convtol || dev == 0
             cvg = true
             break
         end
         @assert isfinite(crit)
         devold = dev
     end
-    cvg || throw(ConvergenceException(maxIter))
+    cvg || throw(ConvergenceException(maxiter))
     m.fit = true
     m
 end
 
-StatsBase.fit!(m::AbstractGLM; verbose::Bool=false, maxIter::Integer=30,
-              minStepFac::Real=0.001, convTol::Real=1.e-6, start=nothing) =
-    _fit!(m, verbose, maxIter, minStepFac, convTol, start)
+function StatsBase.fit!(m::AbstractGLM; verbose::Bool=false, maxiter::Integer=30,
+                        minstepfac::Real=0.001, convtol::Real=1e-6, start=nothing)
+    if haskey(kwargs, :maxIter)
+        Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
+        maxiter = kwargs[:maxIter]
+    end
+    if haskey(kwargs, :minStepFac)
+        Base.depwarn("'minStepFac' argument is deprecated, use 'minstepfac' instead", :fit!)
+        minstepfac = kwargs[:minStepFac]
+    end
+    if haskey(kwargs, :convTol)
+        Base.depwarn("'convTol' argument is deprecated, use 'convtol' instead", :fit!)
+        convtol = kwargs[:convTol]
+    end
+    if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
+        throw(ArgumentError("unsupported keyword argument"))
+    end
+
+    _fit!(m, verbose, maxiter, minstepfac, convtol, start)
+end
 
 function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::Bool=true,
-                        verbose::Bool=false, maxIter::Integer=30, minStepFac::Real=0.001, convTol::Real=1.e-6,
-                        start=nothing)
+                        verbose::Bool=false, maxiter::Integer=30, minstepfac::Real=0.001,
+                        convtol::Real=1e-6, start=nothing, kwargs...)
+    if haskey(kwargs, :maxIter)
+        Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
+        maxiter = kwargs[:maxIter]
+    end
+    if haskey(kwargs, :minStepFac)
+        Base.depwarn("'minStepFac' argument is deprecated, use 'minstepfac' instead", :fit!)
+        minstepfac = kwargs[:minStepFac]
+    end
+    if haskey(kwargs, :convTol)
+        Base.depwarn("'convTol' argument is deprecated, use 'convtol' instead", :fit!)
+        convtol = kwargs[:convTol]
+    end
+    if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
+        throw(ArgumentError("unsupported keyword argument"))
+    end
+
     r = m.rr
     V = typeof(r.y)
     r.y = copy!(r.y, y)
@@ -290,7 +323,7 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
     fill!(m.pp.beta0, 0)
     m.fit = false
     if dofit
-        _fit!(m, verbose, maxIter, minStepFac, convTol, start)
+        _fit!(m, verbose, maxiter, minstepfac, convtol, start)
     else
         m
     end
@@ -305,10 +338,10 @@ vector, respectively, or a formula and a data frame. `d` must be a
 
 # Keyword Arguments
 - `verbose::Bool=false`: Display convergence information for each iteration
-- `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
-- `convTol::Real=1e-6`: Convergence is achieved when the relative change in
+- `maxiter::Integer=30`: Maximum number of iterations allowed to achieve convergence
+- `convtol::Real=1e-6`: Convergence is achieved when the relative change in
 deviance is less than this
-- `minStepFac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
+- `minstepfac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
 - `start::AbstractVector=nothing`: Starting values for beta. Should have the
 same length as the number of columns in the model matrix.
 """

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -274,7 +274,8 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
 end
 
 function StatsBase.fit!(m::AbstractGLM; verbose::Bool=false, maxiter::Integer=30,
-                        minstepfac::Real=0.001, convtol::Real=1e-6, start=nothing)
+                        minstepfac::Real=0.001, convtol::Real=1e-6, start=nothing,
+                        kwargs...)
     if haskey(kwargs, :maxIter)
         Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
         maxiter = kwargs[:maxIter]

--- a/src/negbinfit.jl
+++ b/src/negbinfit.jl
@@ -1,5 +1,5 @@
 function mle_for_θ(y::AbstractVector, μ::AbstractVector, wts::AbstractVector;
-                   maxIter=30, convTol=1.e-6)
+                   maxiter=30, convtol=1.e-6)
     function first_derivative(θ::Real)
         tmp(yi, μi) = (yi+θ)/(μi+θ) + log(μi+θ) - 1 - log(θ) - digamma(θ+yi) + digamma(θ)
         unit_weights ? sum(tmp(yi, μi) for (yi, μi) in zip(y, μ)) :
@@ -21,33 +21,49 @@ function mle_for_θ(y::AbstractVector, μ::AbstractVector, wts::AbstractVector;
     end
     δ, converged = one(θ), false
 
-    for t = 1:maxIter
+    for t = 1:maxiter
         θ = abs(θ)
         δ = first_derivative(θ) / second_derivative(θ)
-        if abs(δ) <= convTol
+        if abs(δ) <= convtol
             converged = true
             break
         end
         θ = θ - δ
     end
-    converged || throw(ConvergenceException(maxIter))
+    converged || throw(ConvergenceException(maxiter))
     θ
 end
 
 function negbin(F, D, args...;
-                initialθ::Real=Inf, maxIter::Integer=30, convTol::Real=1.e-6,
+                initialθ::Real=Inf, maxiter::Integer=30, convtol::Real=1.e-6,
                 verbose::Bool=false, kwargs...)
-    maxIter >= 1 || throw(ArgumentError("maxIter must be positive"))
-    convTol > 0  || throw(ArgumentError("convTol must be positive"))
+    if haskey(kwargs, :maxIter)
+        Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
+        maxiter = kwargs[:maxIter]
+    end
+    if haskey(kwargs, :minStepFac)
+        Base.depwarn("'minStepFac' argument is deprecated, use 'minstepfac' instead", :fit!)
+        minstepfac = kwargs[:minStepFac]
+    end
+    if haskey(kwargs, :convTol)
+        Base.depwarn("'convTol' argument is deprecated, use 'convtol' instead", :fit!)
+        convtol = kwargs[:convTol]
+    end
+    if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
+        throw(ArgumentError("unsupported keyword argument"))
+    end
+
+    maxiter >= 1 || throw(ArgumentError("maxiter must be positive"))
+    convtol > 0  || throw(ArgumentError("convtol must be positive"))
     initialθ > 0 || throw(ArgumentError("initialθ must be positive"))
 
     # fit a Poisson regression model if the user does not specify an initial θ
     if isinf(initialθ) 
         regmodel = glm(F, D, Poisson(), args...;
-                       maxIter=maxIter, convTol=convTol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, convtol=convtol, verbose=verbose, kwargs...)
     else
         regmodel = glm(F, D, NegativeBinomial(initialθ), args...;
-                       maxIter=maxIter, convTol=convTol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, convtol=convtol, verbose=verbose, kwargs...)
     end
 
     μ = regmodel.model.rr.mu
@@ -65,21 +81,21 @@ function negbin(F, D, args...;
     ll0 = ll + 2 * d
 
     converged = false
-    for i = 1:maxIter
-        if abs(ll0 - ll)/d + abs(δ) <= convTol
+    for i = 1:maxiter
+        if abs(ll0 - ll)/d + abs(δ) <= convtol
             converged = true
             break
         end
         verbose && println("[ Alternating iteration ", i, ", θ = ", θ, " ]")
         regmodel = glm(F, D, NegativeBinomial(θ), args...;
-                       maxIter=maxIter, convTol=convTol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, convtol=convtol, verbose=verbose, kwargs...)
         μ = regmodel.model.rr.mu
         prevθ = θ
-        θ = mle_for_θ(y, μ, wts; maxIter=maxIter, convTol=convTol)
+        θ = mle_for_θ(y, μ, wts; maxiter=maxiter, convtol=convtol)
         δ = prevθ - θ
         ll0 = ll
         ll = loglikelihood(regmodel)
     end
-    converged || throw(ConvergenceException(maxIter))
+    converged || throw(ConvergenceException(maxiter))
     regmodel
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,7 +186,7 @@ end
 
 @testset "Normal LogLink offset" begin
     gm7 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
-              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), convTol=1e-8)
+              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), convtol=1e-8)
     @test !GLM.cancancel(gm7.model.rr)
     test_show(gm7)
     @test isapprox(deviance(gm7), 3265.207242977156)
@@ -236,7 +236,7 @@ end
 
 @testset "Gamma LogLink" begin
     gm9 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), LogLink(),
-              convTol=1e-8)
+              convtol=1e-8)
     @test !GLM.cancancel(gm9.model.rr)
     test_show(gm9)
     @test dof(gm9) == 3
@@ -252,7 +252,7 @@ end
 
 @testset "Gamma IdentityLink" begin
     gm10 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), IdentityLink(),
-               convTol=1e-8)
+               convtol=1e-8)
     @test !GLM.cancancel(gm10.model.rr)
     test_show(gm10)
     @test dof(gm10) == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,7 +186,7 @@ end
 
 @testset "Normal LogLink offset" begin
     gm7 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
-              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), convtol=1e-8)
+              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), tol=1e-8)
     @test !GLM.cancancel(gm7.model.rr)
     test_show(gm7)
     @test isapprox(deviance(gm7), 3265.207242977156)
@@ -236,7 +236,7 @@ end
 
 @testset "Gamma LogLink" begin
     gm9 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), LogLink(),
-              convtol=1e-8)
+              tol=1e-8)
     @test !GLM.cancancel(gm9.model.rr)
     test_show(gm9)
     @test dof(gm9) == 3
@@ -252,7 +252,7 @@ end
 
 @testset "Gamma IdentityLink" begin
     gm10 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), IdentityLink(),
-               convtol=1e-8)
+               tol=1e-8)
     @test !GLM.cancancel(gm10.model.rr)
     test_show(gm10)
     @test dof(gm10) == 3


### PR DESCRIPTION
We could take the occasion to rename arguments. Maybe `tolerance` would be better than `convtol`? FWIW [FixedEffectsModels](https://github.com/matthieugomez/FixedEffectModels.jl/blob/c64231417ab5b874317e4e00f1497b09332e0a60/src/reg.jl#L11) and [StatsModels.org](http://www.statsmodels.org/stable/generated/statsmodels.genmod.generalized_linear_model.GLM.fit.html#statsmodels.genmod.generalized_linear_model.GLM.fit) use `tol`, so we could use that too.

BTW, `allowrankdeficient` is still a positional argument, should we make it a keyword? And if so under what name?