### PR TITLE
Add more documentation for keyword arguments used to fit GLMs

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -306,7 +306,8 @@ vector, respectively, or a formula and a data frame. `d` must be a
 # Keyword Arguments
 - `dofit::Bool=true`: Determines whether model will be fit
 - `wts::Vector=similar(y,0)`: prior case weights. Can be length 0.
-- `offset::V=similar(y,0)`: offset added to `Xβ` to form `eta`.  Can be of length 0
+- `offset::Vector=similar(y,0)`: offset added to `Xβ` to form `eta`.  Can be of
+length 0
 - `verbose::Bool=false`: Display convergence information for each iteration
 - `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
 - `convTol::Real=1e-6`: Convergence is achieved when the relative change in

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -304,6 +304,9 @@ vector, respectively, or a formula and a data frame. `d` must be a
 `UnivariateDistribution`, and `l` must be a [`Link`](@ref), if supplied.
 
 # Keyword Arguments
+- `dofit::Bool=true`: Determines whether model will be fit
+- `wts::Vector=similar(y,0)`: prior case weights. Can be length 0.
+- `offset::V=similar(y,0)`: offset added to `Xβ` to form `eta`.  Can be of length 0
 - `verbose::Bool=false`: Display convergence information for each iteration
 - `maxIter::Integer=30`: Maximum number of iterations allowed to achieve convergence
 - `convTol::Real=1e-6`: Convergence is achieved when the relative change in

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -158,6 +158,37 @@ mutable struct GeneralizedLinearModel{G<:GlmResp,L<:LinPred} <: AbstractGLM
     fit::Bool
 end
 
+"""
+    coeftable(mm::AbstractGLM)
+
+Return the `CoefTable` (see StatsBase.jl for documentation) for a GLM fit. Can
+be used to access the z value and significance of model parameters.
+
+# Examples
+```jldoctest
+julia> data = DataFrame(X=[1,2,2], Y=[1,0,1])
+3×2 DataFrames.DataFrame
+│ Row │ X     │ Y     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 1     │
+│ 2   │ 2     │ 0     │
+│ 3   │ 2     │ 1     │
+
+julia> probit = glm(@formula(Y ~ X), data, Binomial(), ProbitLink())
+StatsModels.DataFrameRegressionModel{GeneralizedLinearModel{GlmResp{Array{Float64,1},Binomial{Float64},ProbitLink},DensePredChol{Float64,LinearAlgebra.Cholesky{Float64,Array{Float64,2}}}},Array{Float64,2}}
+
+Formula: Y ~ 1 + X
+
+Coefficients:
+             Estimate Std.Error    z value Pr(>|z|)
+(Intercept)   9.63839   293.909  0.0327937   0.9738
+X            -4.81919   146.957 -0.0327933   0.9738
+
+julia> coeftable(probit).cols[4][1] # Access the p-value of the intercept
+0.9738
+```
+"""
 function coeftable(mm::AbstractGLM)
     cc = coef(mm)
     se = stderror(mm)

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -158,37 +158,6 @@ mutable struct GeneralizedLinearModel{G<:GlmResp,L<:LinPred} <: AbstractGLM
     fit::Bool
 end
 
-"""
-    coeftable(mm::AbstractGLM)
-
-Return the `CoefTable` (see StatsBase.jl for documentation) for a GLM fit. Can
-be used to access the z value and significance of model parameters.
-
-# Examples
-```jldoctest
-julia> data = DataFrame(X=[1,2,2], Y=[1,0,1])
-3×2 DataFrames.DataFrame
-│ Row │ X     │ Y     │
-│     │ Int64 │ Int64 │
-├─────┼───────┼───────┤
-│ 1   │ 1     │ 1     │
-│ 2   │ 2     │ 0     │
-│ 3   │ 2     │ 1     │
-
-julia> probit = glm(@formula(Y ~ X), data, Binomial(), ProbitLink())
-StatsModels.DataFrameRegressionModel{GeneralizedLinearModel{GlmResp{Array{Float64,1},Binomial{Float64},ProbitLink},DensePredChol{Float64,LinearAlgebra.Cholesky{Float64,Array{Float64,2}}}},Array{Float64,2}}
-
-Formula: Y ~ 1 + X
-
-Coefficients:
-             Estimate Std.Error    z value Pr(>|z|)
-(Intercept)   9.63839   293.909  0.0327937   0.9738
-X            -4.81919   146.957 -0.0327933   0.9738
-
-julia> coeftable(probit).cols[4][1] # Access the p-value of the intercept
-0.9738
-```
-"""
 function coeftable(mm::AbstractGLM)
     cc = coef(mm)
     se = stderror(mm)


### PR DESCRIPTION
Some important keyword arguments were not specified for
`fit(GeneralizedLienarModel, ...)`, such as `offset`. This commit copies the
documentation from `GlmResp` to the corresponding keyword arguments of `fit`.