### PR TITLE
Pass stopping criteria to mle_for_θ

### DIFF
--- a/src/negbinfit.jl
+++ b/src/negbinfit.jl
@@ -58,7 +58,7 @@ function negbin(F, D, args...;
         throw(ArgumentError("length of wts must be either $ly or 0 but was $lw"))
     end
 
-    θ = mle_for_θ(y, μ, wts)
+    θ = mle_for_θ(y, μ, wts; maxIter = maxIter, convTol = convTol)
     d = sqrt(2 * max(1, deviance(regmodel)))
     δ = one(θ)
     ll = loglikelihood(regmodel)

--- a/src/negbinfit.jl
+++ b/src/negbinfit.jl
@@ -58,7 +58,7 @@ function negbin(F, D, args...;
         throw(ArgumentError("length of wts must be either $ly or 0 but was $lw"))
     end
 
-    θ = mle_for_θ(y, μ, wts; maxIter = maxIter, convTol = convTol)
+    θ = mle_for_θ(y, μ, wts; maxiter=maxiter, tol=tol)
     d = sqrt(2 * max(1, deviance(regmodel)))
     δ = one(θ)
     ll = loglikelihood(regmodel)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,6 +385,19 @@ end
     @test isapprox(coef(gm20)[1:7],
         [2.894527697811509, -0.5693411448715979, 0.08238813087070128, -0.4484636623590206,
          0.08805060372902418, 0.3569553124412582, 0.2921383118842893])
+
+    # Issue #302
+    let df = DataFrame(
+        ;y = [1, 1, 0, 2, 3, 0, 0, 1, 1, 0, 2, 1, 3, 1, 1, 1, 4, 1, 2, 4]
+    )
+        for maxIter in [30, 50]
+            try
+                negbin(@formula(y ~ 1), df, maxIter = maxIter)
+            catch err
+                @test err.msg == "failure to converge after $(maxIter) iterations."
+            end
+        end
+    end
 end
 
 @testset "NegativeBinomial NegativeBinomialLink, θ to be estimated" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,16 +386,14 @@ end
         [2.894527697811509, -0.5693411448715979, 0.08238813087070128, -0.4484636623590206,
          0.08805060372902418, 0.3569553124412582, 0.2921383118842893])
 
-    # Issue #302
-    let df = DataFrame(
-        ;y = [1, 1, 0, 2, 3, 0, 0, 1, 1, 0, 2, 1, 3, 1, 1, 1, 4, 1, 2, 4]
-    )
+    @testset "NegativeBinomial Parameter estimation" begin
+        # Issue #302
+        df = DataFrame(y = [1, 1, 0, 2, 3, 0, 0, 1, 1, 0, 2, 1, 3, 1, 1, 1, 4])
         for maxIter in [30, 50]
             try
                 negbin(@formula(y ~ 1), df, maxIter = maxIter)
             catch err
-                errmsg = sprint(showerror, err)
-                @test errmsg == "failure to converge after $(maxIter) iterations."
+                @test err.iters == maxIter
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -389,11 +389,11 @@ end
     @testset "NegativeBinomial Parameter estimation" begin
         # Issue #302
         df = DataFrame(y = [1, 1, 0, 2, 3, 0, 0, 1, 1, 0, 2, 1, 3, 1, 1, 1, 4])
-        for maxIter in [30, 50]
+        for maxiter in [30, 50]
             try
-                negbin(@formula(y ~ 1), df, maxIter = maxIter)
+                negbin(@formula(y ~ 1), df, maxiter = maxiter)
             catch err
-                @test err.iters == maxIter
+                @test err.iters == maxiter
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,7 +394,8 @@ end
             try
                 negbin(@formula(y ~ 1), df, maxIter = maxIter)
             catch err
-                @test err.msg == "failure to converge after $(maxIter) iterations."
+                errmsg = sprint(showerror, err)
+                @test errmsg == "failure to converge after $(maxIter) iterations."
             end
         end
     end


### PR DESCRIPTION
`negbin` relies on helper function `mle_for_θ` to estimate the parameter θ, but
the stopping criteria `maxIter` and `convTol` were not being passed from
`negbin` to `mle_for_θ`.