### PR TITLE
RFC: Compute working weights and residuals more carefully to reduce underflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ test = ["CategoricalArrays", "CSV", "DataFrames", "RDatasets", "Test"]
 [compat]
 CategoricalArrays = "0.3, 0.4, 0.5"
 CSV = "0.2, 0.3, 0.4"
-DataFrames = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
+DataFrames = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 Distributions = "0.16, 0.17, 0.18, 0.19"
 RDatasets = "0.5, 0.6"
 Reexport = "0.1, 0.2"

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -355,14 +355,14 @@ function StatsBase.fit!(m::AbstractGLM;
     end
     if haskey(kwargs, :convTol)
         Base.depwarn("'convTol' argument is deprecated, use `atol` and `rtol` instead", :fit!)
-        tol = kwargs[:convTol]
+        rtol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
     end
     if haskey(kwargs, :tol)
         Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :fit!)
-        tol = kwargs[:tol]
+        rtol = kwargs[:tol]
     end
 
     _fit!(m, verbose, maxiter, minstepfac, atol, rtol, start)
@@ -390,14 +390,14 @@ function StatsBase.fit!(m::AbstractGLM,
     end
     if haskey(kwargs, :convTol)
         Base.depwarn("'convTol' argument is deprecated, use `atol` and `rtol` instead", :fit!)
-        tol = kwargs[:convTol]
+        rtol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
     end
     if haskey(kwargs, :tol)
         Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :fit!)
-        tol = kwargs[:tol]
+        rtol = kwargs[:tol]
     end
 
     r = m.rr

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -106,16 +106,79 @@ function updateμ!(r::GlmResp{V,D,L}) where {V<:FPVector,D,L}
     end
 end
 
+function _weights_residuals(yᵢ, ηᵢ, μᵢ, omμᵢ, dμdηᵢ, l::LogitLink)
+    # LogitLink is the canonical link function for Binomial so only wrkresᵢ can
+    # possibly fail when dμdη==0 in which case it evaluates to ±1.
+    if iszero(dμdηᵢ)
+        wrkresᵢ = ifelse(yᵢ == 1, one(μᵢ), -one(μᵢ))
+    else
+        wrkresᵢ = ifelse(yᵢ == 1, omμᵢ, yᵢ - μᵢ) / dμdηᵢ
+    end
+    wrkwtᵢ = μᵢ*omμᵢ
+
+    return wrkresᵢ, wrkwtᵢ
+end
+
+function _weights_residuals(yᵢ, ηᵢ, μᵢ, omμᵢ, dμdηᵢ, l::ProbitLink)
+    # Since μomμ will underflow before dμdη for Probit, we can just check the
+    # former to decide when to evaluate with the tail approximation.
+    μomμᵢ = μᵢ*omμᵢ
+    if iszero(μomμᵢ)
+        wrkresᵢ = 1/abs(ηᵢ)
+        wrkwtᵢ  = dμdηᵢ
+    else
+        wrkresᵢ = ifelse(yᵢ == 1, omμᵢ, yᵢ - μᵢ) / dμdηᵢ
+        wrkwtᵢ  = abs2(dμdηᵢ)/μomμᵢ
+    end
+
+    return wrkresᵢ, wrkwtᵢ
+end
+
+function _weights_residuals(yᵢ, ηᵢ, μᵢ, omμᵢ, dμdηᵢ, l::CloglogLink)
+    if yᵢ == 1
+        wrkresᵢ = exp(-ηᵢ)
+    else
+        emη = exp(-ηᵢ)
+        if iszero(emη)
+            # Diverges to -∞
+            wrkresᵢ = -typeof(wrkresᵢ)(Inf)
+        elseif isinf(emη)
+            # converges to -1
+            wrkresᵢ = -one(emη)
+        else
+            wrkresᵢ = (yᵢ - μᵢ)/omμᵢ*emη
+        end
+    end
+
+    wrkwtᵢ  = exp(2*ηᵢ)/expm1(exp(ηᵢ))
+    # We know that both limits are zero so we'll convert NaNs
+    wrkwtᵢ = ifelse(isnan(wrkwtᵢ), zero(wrkwtᵢ), wrkwtᵢ)
+
+    return wrkresᵢ, wrkwtᵢ
+end
+
+# Fallback for remaining link functions
+function _weights_residuals(yᵢ, ηᵢ, μᵢ, omμᵢ, dμdηᵢ, l::Link01)
+    wrkresᵢ = ifelse(yᵢ == 1, omμᵢ, yᵢ - μᵢ)/dμdηᵢ
+    wrkwtᵢ  = abs2(dμdηᵢ)/(μᵢ*omμᵢ)
+
+    return wrkresᵢ, wrkwtᵢ
+end
+
 function updateμ!(r::GlmResp{V,D,L}) where {V<:FPVector,D<:Union{Bernoulli,Binomial},L<:Link01}
     y, η, μ, wrkres, wrkwt, dres = r.y, r.eta, r.mu, r.wrkresid, r.wrkwt, r.devresid
 
     @inbounds for i in eachindex(y, η, μ, wrkres, wrkwt, dres)
-        μi, dμdη, μomμ = inverselink(L(), η[i])
-        μ[i] = μi
-        yi = y[i]
-        wrkres[i] = (yi - μi) / dμdη
-        wrkwt[i] = cancancel(r) ? dμdη : abs2(dμdη) / μomμ
-        dres[i] = devresid(r.d, yi, μi)
+        yᵢ, ηᵢ = y[i], η[i]
+        μᵢ, omμᵢ, dμdηᵢ = inverselink(L(), ηᵢ)
+        μ[i] = μᵢ
+        # For large values of ηᵢ the quantities dμdη and μomμ will underflow.
+        # The ratios defining (yᵢ - μᵢ)/dμdη and dμdη^2/μomμ have fairly stable
+        # tail behavior so we can switch algorithm to avoid 0/0. The behavior
+        # is specific to the link function so _weights_residuals dispatches to
+        # robust versions for LogitLink and ProbitLink
+        wrkres[i], wrkwt[i] = _weights_residuals(yᵢ, ηᵢ, μᵢ, omμᵢ, dμdηᵢ, L())
+        dres[i] = devresid(r.d, yᵢ, μᵢ)
     end
 end
 
@@ -200,7 +263,7 @@ end
 dof(x::GeneralizedLinearModel) = dispersion_parameter(x.rr.d) ? length(coef(x)) + 1 : length(coef(x))
 
 function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real,
-               tol::Real, start)
+               atol::Real, rtol::Real, start)
 
     # Return early if model has the fit flag set
     m.fit && return m
@@ -246,9 +309,9 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
 
         # Line search
         ## If the deviance isn't declining then half the step size
-        ## The tol*dev term is to avoid failure when deviance
+        ## The rtol*dev term is to avoid failure when deviance
         ## is unchanged except for rouding errors.
-        while dev > devold + tol*dev
+        while dev > devold + rtol*dev
             f /= 2
             f > minstepfac || error("step-halving failed at beta0 = $(p.beta0)")
             try
@@ -261,13 +324,12 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
         installbeta!(p, f)
 
         # Test for convergence
-        crit = (devold - dev)/dev
-        verbose && println("$i: $dev, $crit")
-        if crit < tol || dev == 0
+        verbose && println("Iteration: $i, deviance: $dev, diff.dev.:$(devold - dev)")
+        if devold - dev < max(rtol*devold, atol)
             cvg = true
             break
         end
-        @assert isfinite(crit)
+        @assert isfinite(dev)
         devold = dev
     end
     cvg || throw(ConvergenceException(maxiter))
@@ -275,8 +337,13 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
     m
 end
 
-function StatsBase.fit!(m::AbstractGLM; verbose::Bool=false, maxiter::Integer=30,
-                        minstepfac::Real=0.001, tol::Real=1e-6, start=nothing,
+function StatsBase.fit!(m::AbstractGLM;
+                        verbose::Bool=false,
+                        maxiter::Integer=30,
+                        minstepfac::Real=0.001,
+                        atol::Real=1e-6,
+                        rtol::Real=1e-6,
+                        start=nothing,
                         kwargs...)
     if haskey(kwargs, :maxIter)
         Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
@@ -287,19 +354,32 @@ function StatsBase.fit!(m::AbstractGLM; verbose::Bool=false, maxiter::Integer=30
         minstepfac = kwargs[:minStepFac]
     end
     if haskey(kwargs, :convTol)
-        Base.depwarn("'convTol' argument is deprecated, use 'tol' instead", :fit!)
+        Base.depwarn("'convTol' argument is deprecated, use `atol` and `rtol` instead", :fit!)
         tol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
     end
+    if haskey(kwargs, :tol)
+        Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :fit!)
+        tol = kwargs[:tol]
+    end
 
-    _fit!(m, verbose, maxiter, minstepfac, tol, start)
+    _fit!(m, verbose, maxiter, minstepfac, atol, rtol, start)
 end
 
-function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::Bool=true,
-                        verbose::Bool=false, maxiter::Integer=30, minstepfac::Real=0.001,
-                        tol::Real=1e-6, start=nothing, kwargs...)
+function StatsBase.fit!(m::AbstractGLM,
+                        y;
+                        wts=nothing,
+                        offset=nothing,
+                        dofit::Bool=true,
+                        verbose::Bool=false,
+                        maxiter::Integer=30,
+                        minstepfac::Real=0.001,
+                        atol::Real=1e-6,
+                        rtol::Real=1e-6,
+                        start=nothing,
+                        kwargs...)
     if haskey(kwargs, :maxIter)
         Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
         maxiter = kwargs[:maxIter]
@@ -309,11 +389,15 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
         minstepfac = kwargs[:minStepFac]
     end
     if haskey(kwargs, :convTol)
-        Base.depwarn("'convTol' argument is deprecated, use 'tol' instead", :fit!)
+        Base.depwarn("'convTol' argument is deprecated, use `atol` and `rtol` instead", :fit!)
         tol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
+    end
+    if haskey(kwargs, :tol)
+        Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :fit!)
+        tol = kwargs[:tol]
     end
 
     r = m.rr
@@ -326,7 +410,7 @@ function StatsBase.fit!(m::AbstractGLM, y; wts=nothing, offset=nothing, dofit::B
     fill!(m.pp.beta0, 0)
     m.fit = false
     if dofit
-        _fit!(m, verbose, maxiter, minstepfac, tol, start)
+        _fit!(m, verbose, maxiter, minstepfac, atol, rtol, start)
     else
         m
     end
@@ -346,8 +430,10 @@ vector, respectively, or a formula and a data frame. `d` must be a
 length 0
 - `verbose::Bool=false`: Display convergence information for each iteration
 - `maxiter::Integer=30`: Maximum number of iterations allowed to achieve convergence
-- `tol::Real=1e-6`: Convergence is achieved when the relative change in
-deviance is less than this
+- `atol::Real=1e-6`: Convergence is achieved when the relative change in
+deviance is less than `max(rtol*dev, atol)`.
+- `rtol::Real=1e-6`: Convergence is achieved when the relative change in
+deviance is less than `max(rtol*dev, atol)`.
 - `minstepfac::Real=0.001`: Minimum line step fraction. Must be between 0 and 1.
 - `start::AbstractVector=nothing`: Starting values for beta. Should have the
 same length as the number of columns in the model matrix.
@@ -373,11 +459,11 @@ function fit(::Type{M},
 end
 
 fit(::Type{M},
-X::Union{Matrix,SparseMatrixCSC},
-y::AbstractVector,
-d::UnivariateDistribution,
-l::Link=canonicallink(d); kwargs...) where {M<:AbstractGLM} =
-    fit(M, float(X), float(y), d, l; kwargs...)
+    X::Union{Matrix,SparseMatrixCSC},
+    y::AbstractVector,
+    d::UnivariateDistribution,
+    l::Link=canonicallink(d); kwargs...) where {M<:AbstractGLM} =
+        fit(M, float(X), float(y), d, l; kwargs...)
 
 """
     glm(F, D, args...; kwargs...)
@@ -485,4 +571,3 @@ function checky(y, d::Binomial)
     end
     return nothing
 end
-

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -151,7 +151,8 @@ end
 function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}, wt::Vector{T}) where T<:BlasReal
     scr = mul!(p.scratchm1, Diagonal(wt), p.X)
     cholesky!(Hermitian(mul!(cholfactors(p.chol), transpose(scr), p.X), :U))
-    ldiv!(p.chol, mul!(p.delbeta, transpose(scr), r))
+    mul!(p.delbeta, transpose(scr), r)
+    ldiv!(p.chol, p.delbeta)
     p
 end
 

--- a/src/negbinfit.jl
+++ b/src/negbinfit.jl
@@ -52,15 +52,15 @@ function negbin(F,
         minstepfac = kwargs[:minStepFac]
     end
     if haskey(kwargs, :convTol)
-        Base.depwarn("'convTol' argument is deprecated, use 'tol' instead", :negbin)
-        tol = kwargs[:convTol]
+        Base.depwarn("`convTol` argument is deprecated, use `atol` and `rtol` instead", :negbin)
+        rtol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
     end
     if haskey(kwargs, :tol)
         Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :negbin)
-        tol = kwargs[:tol]
+        rtol = kwargs[:tol]
     end
 
     maxiter >= 1 || throw(ArgumentError("maxiter must be positive"))

--- a/src/negbinfit.jl
+++ b/src/negbinfit.jl
@@ -13,7 +13,7 @@ function mle_for_θ(y::AbstractVector, μ::AbstractVector, wts::AbstractVector;
 
     unit_weights = length(wts) == 0
     if unit_weights
-        n = length(y) 
+        n = length(y)
         θ = n / sum((yi/μi - 1)^2 for (yi, μi) in zip(y, μ))
     else
         n = sum(wts)
@@ -34,36 +34,47 @@ function mle_for_θ(y::AbstractVector, μ::AbstractVector, wts::AbstractVector;
     θ
 end
 
-function negbin(F, D, args...;
-                initialθ::Real=Inf, maxiter::Integer=30, tol::Real=1.e-6,
-                verbose::Bool=false, kwargs...)
+function negbin(F,
+                D,
+                args...;
+                initialθ::Real=Inf,
+                maxiter::Integer=30,
+                atol::Real=1e-6,
+                rtol::Real=1.e-6,
+                verbose::Bool=false,
+                kwargs...)
     if haskey(kwargs, :maxIter)
-        Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :fit!)
+        Base.depwarn("'maxIter' argument is deprecated, use 'maxiter' instead", :negbin)
         maxiter = kwargs[:maxIter]
     end
     if haskey(kwargs, :minStepFac)
-        Base.depwarn("'minStepFac' argument is deprecated, use 'minstepfac' instead", :fit!)
+        Base.depwarn("'minStepFac' argument is deprecated, use 'minstepfac' instead", :negbin)
         minstepfac = kwargs[:minStepFac]
     end
     if haskey(kwargs, :convTol)
-        Base.depwarn("'convTol' argument is deprecated, use 'tol' instead", :fit!)
+        Base.depwarn("'convTol' argument is deprecated, use 'tol' instead", :negbin)
         tol = kwargs[:convTol]
     end
     if !issubset(keys(kwargs), (:maxIter, :minStepFac, :convTol))
         throw(ArgumentError("unsupported keyword argument"))
     end
+    if haskey(kwargs, :tol)
+        Base.depwarn("`tol` argument is deprecated, use `atol` and `rtol` instead", :negbin)
+        tol = kwargs[:tol]
+    end
 
     maxiter >= 1 || throw(ArgumentError("maxiter must be positive"))
-    tol > 0  || throw(ArgumentError("tol must be positive"))
+    atol > 0  || throw(ArgumentError("atol must be positive"))
+    rtol > 0  || throw(ArgumentError("rtol must be positive"))
     initialθ > 0 || throw(ArgumentError("initialθ must be positive"))
 
     # fit a Poisson regression model if the user does not specify an initial θ
-    if isinf(initialθ) 
+    if isinf(initialθ)
         regmodel = glm(F, D, Poisson(), args...;
-                       maxiter=maxiter, tol=tol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, atol=atol, rtol=rtol, verbose=verbose, kwargs...)
     else
         regmodel = glm(F, D, NegativeBinomial(initialθ), args...;
-                       maxiter=maxiter, tol=tol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, atol=atol, rtol=rtol, verbose=verbose, kwargs...)
     end
 
     μ = regmodel.model.rr.mu
@@ -82,16 +93,16 @@ function negbin(F, D, args...;
 
     converged = false
     for i = 1:maxiter
-        if abs(ll0 - ll)/d + abs(δ) <= tol
+        if abs(ll0 - ll)/d + abs(δ) <= rtol
             converged = true
             break
         end
         verbose && println("[ Alternating iteration ", i, ", θ = ", θ, " ]")
         regmodel = glm(F, D, NegativeBinomial(θ), args...;
-                       maxiter=maxiter, tol=tol, verbose=verbose, kwargs...)
+                       maxiter=maxiter, atol=atol, rtol=rtol, verbose=verbose, kwargs...)
         μ = regmodel.model.rr.mu
         prevθ = θ
-        θ = mle_for_θ(y, μ, wts; maxiter=maxiter, tol=tol)
+        θ = mle_for_θ(y, μ, wts; maxiter=maxiter, tol=rtol)
         δ = prevθ - θ
         ll0 = ll
         ll = loglikelihood(regmodel)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,22 +92,19 @@ end
 admit = CSV.read(joinpath(glm_datadir, "admit.csv"))
 admit[:rank] = categorical(admit[:rank])
 
-@testset "Binomial, Bernoulli, LogitLink" begin
-    for distr in (Binomial, Bernoulli)
-        gm2 = fit(GeneralizedLinearModel, @formula(admit ~ 1 + gre + gpa + rank), admit,
-                  distr())
-        @test GLM.cancancel(gm2.model.rr)
-        test_show(gm2)
-        @test dof(gm2) == 6
-        @test isapprox(deviance(gm2), 458.5174924758994)
-        @test isapprox(loglikelihood(gm2), -229.25874623794968)
-        @test isapprox(aic(gm2), 470.51749247589936)
-        @test isapprox(aicc(gm2), 470.7312329339146)
-        @test isapprox(bic(gm2), 494.4662797585473)
-        @test isapprox(coef(gm2),
-            [-3.9899786606380756, 0.0022644256521549004, 0.804037453515578,
-            -0.6754428594116578, -1.340203811748108, -1.5514636444657495])
-    end
+@testset "$distr with LogitLink" for distr in (Binomial, Bernoulli)
+    gm2 = fit(GeneralizedLinearModel, @formula(admit ~ 1 + gre + gpa + rank), admit, distr())
+    @test GLM.cancancel(gm2.model.rr)
+    test_show(gm2)
+    @test dof(gm2) == 6
+    @test deviance(gm2) ≈ 458.5174924758994
+    @test loglikelihood(gm2) ≈ -229.25874623794968
+    @test isapprox(aic(gm2), 470.51749247589936)
+    @test isapprox(aicc(gm2), 470.7312329339146)
+    @test isapprox(bic(gm2), 494.4662797585473)
+    @test isapprox(coef(gm2),
+        [-3.9899786606380756, 0.0022644256521549004, 0.804037453515578,
+         -0.6754428594116578, -1.340203811748108, -1.5514636444657495])
 end
 
 @testset "Bernoulli ProbitLink" begin
@@ -187,7 +184,7 @@ end
 
 @testset "Normal LogLink offset" begin
     gm7 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
-              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), tol=1e-8)
+              Normal(), LogLink(), offset=Array{Float64}(anorexia[:Prewt]), rtol=1e-8)
     @test !GLM.cancancel(gm7.model.rr)
     test_show(gm7)
     @test isapprox(deviance(gm7), 3265.207242977156)
@@ -237,23 +234,23 @@ end
 
 @testset "Gamma LogLink" begin
     gm9 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), LogLink(),
-              tol=1e-8)
+              rtol=1e-8, atol=0.0)
     @test !GLM.cancancel(gm9.model.rr)
     test_show(gm9)
     @test dof(gm9) == 3
-    @test isapprox(deviance(gm9), 0.16260829451739)
-    @test isapprox(loglikelihood(gm9), -26.24082810384911)
-    @test isapprox(aic(gm9), 58.48165620769822)
-    @test isapprox(aicc(gm9), 63.28165620769822)
-    @test isapprox(bic(gm9), 59.07332993970688)
-    @test isapprox(coef(gm9), [5.50322528458221, -0.60191617825971])
-    @test isapprox(GLM.dispersion(gm9.model, true), 0.02435442293561081)
-    @test isapprox(stderror(gm9), [0.19030107482720, 0.05530784660144])
+    @test deviance(gm9) ≈ 0.16260829451739
+    @test loglikelihood(gm9) ≈ -26.24082810384911
+    @test aic(gm9) ≈ 58.48165620769822
+    @test aicc(gm9) ≈ 63.28165620769822
+    @test bic(gm9) ≈ 59.07332993970688
+    @test coef(gm9) ≈ [5.50322528458221, -0.60191617825971]
+    @test GLM.dispersion(gm9.model, true) ≈ 0.02435442293561081
+    @test stderror(gm9) ≈ [0.19030107482720, 0.05530784660144]
 end
 
 @testset "Gamma IdentityLink" begin
     gm10 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), IdentityLink(),
-               tol=1e-8)
+               rtol=1e-8, atol=0.0)
     @test !GLM.cancancel(gm10.model.rr)
     test_show(gm10)
     @test dof(gm10) == 3
@@ -300,14 +297,12 @@ admit_agr2[:p] = admit_agr2[:admit] ./ admit_agr2[:count]
     test_show(gm15)
     @test dof(gm15) == 4
     @test nobs(gm15) == 400
-# The model matrix is singular so the deviance is essentially round-off error
-#    @test isapprox(deviance(gm15), -2.4424906541753456e-15, rtol = 1e-7)
-    @test isapprox(loglikelihood(gm15), -9.50254433604239)
-    @test isapprox(aic(gm15), 27.00508867208478)
-    @test isapprox(aicc(gm15), 27.106354494869592)
-    @test isapprox(bic(gm15), 42.970946860516705)
-    @test isapprox(coef(gm15),
-        [0.1643030512912767, -0.7500299832303851, -1.3646980342693287, -1.6867295867357475])
+    @test deviance(gm15) ≈ -2.4424906541753456e-15 atol = 1e-13
+    @test loglikelihood(gm15) ≈ -9.50254433604239
+    @test aic(gm15) ≈ 27.00508867208478
+    @test aicc(gm15) ≈ 27.106354494869592
+    @test bic(gm15) ≈ 42.970946860516705
+    @test coef(gm15) ≈ [0.1643030512912767, -0.7500299832303851, -1.3646980342693287, -1.6867295867357475]
 end
 
 # Weighted Gamma example (weights are totally made up)
@@ -620,3 +615,12 @@ end
     @test dof_residual(model1) == dof_residual(model2)
     @test dof_residual(model3) == dof_residual(model4)
 end
+
+@testset "Issue #286 (separable data)" begin
+    x  = rand(1000)
+    df = DataFrame(y = x .> 0.5, x₁ = x, x₂ = rand(1000))
+    @testset "Binomial with $l" for l in (LogitLink(), ProbitLink(), CauchitLink(), CloglogLink())
+        @test glm(@formula(y ~ x₁ + x₂), df, Binomial(), l, maxiter=40) isa StatsModels.DataFrameRegressionModel
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -620,7 +620,7 @@ end
     x  = rand(1000)
     df = DataFrame(y = x .> 0.5, x₁ = x, x₂ = rand(1000))
     @testset "Binomial with $l" for l in (LogitLink(), ProbitLink(), CauchitLink(), CloglogLink())
-        @test glm(@formula(y ~ x₁ + x₂), df, Binomial(), l, maxiter=40) isa StatsModels.DataFrameRegressionModel
+        @test deviance(glm(@formula(y ~ x₁ + x₂), df, Binomial(), l, maxiter=40)) < 1e-6
     end
 end
 


### PR DESCRIPTION
This is another attempt at fixing #286. A little explanation of the changes here is probably required. The models are fitted with the iteratively reweighted least squares (IRLS) algorithm which is a version of Newton's method where the Fisher information is used as the Hessian. Each update can be efficiently computed as a weighted least squares problem, i.e. the update becomes
![image](https://user-images.githubusercontent.com/505001/59506470-98c1d300-8ea8-11e9-8f6f-c8a47bca102f.png)

so the two quantities to compute are the weights
![image](https://user-images.githubusercontent.com/505001/59506536-c27afa00-8ea8-11e9-9654-0a6bd631481c.png)

and the weighted residuals
![image](https://user-images.githubusercontent.com/505001/59506582-dde60500-8ea8-11e9-9817-a26517062464.png)

where `μᵢ=μ(ηᵢ)` with `ηᵢ=xᵢ'β` being the linear predictor and `μ` the inverse link function. The current approach in GLM.jl has been to compute `μ`, `dμdη`, and `Var(yᵢ)` and then compute the ratios defining the weights and residuals.

This approach fairly frequently runs into problems in the Bernoulli case (`yᵢ` is either zero or one and `Var(yᵢ) = μᵢ(1-μᵢ)`). The reason is that while `wᵢ` is bounded and `rʷᵢ` moves modestly, the numerator and denominator become small for extreme values of `ηᵢ` causing `NaN`s which is essentially the problem in #286. However, the limits are actually well known for each of the link functions so by using dispatch when computing the weights and residuals it is possible to compute the right limits instead of getting `NaN`. The simplest example here might be for the logit model where it can easily be verified that the residual is either -1, 0, or 1 in the limit.

@dmbates It would be great if you could sanity check what I'm doing here. I'm thinking that it might generally be a good idea to focus the specialized methods on the weights and residuals calculations directly instead of the derivative of the inverse link and the variance function since the two former seem to behave much better. Notice, that I've currently changed what `inverselink` returns for `Link01` links. I'm not sure what the implications are for `MixedModels`. I've also removed the clamping used in `CloglogLink` because they were no longer needed here once I took care of the limits computations for the weights and residuals.

Another part of the issue in #286 is that when there is a perfect fit then a relative convergence criterion isn't working well. Therefore, I've also introduced changed `tol` to `rtol` and introduced `atol`. In total, I believe this should fix #286 and I've added tests for all the `Link01`s to verify that it's the case.