### PR TITLE
Add support for rank deficient `GeneralizedLinearModel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 docs/build
 docs/site
 docs/Manifest.toml
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -37,3 +37,4 @@ StatsBase = "0.30, 0.31"
 StatsFuns = "0.6, 0.7, 0.8"
 StatsModels = "0.6"
 julia = "1"
+

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -7,6 +7,11 @@ The effective coefficient vector, `p.scratchbeta`, is evaluated as `p.beta0 .+ f
 and `out` is updated to `p.X * p.scratchbeta`
 """
 function linpred!(out, p::LinPred, f::Real=1.)
+    for i in eachindex(p.delbeta)
+        if isnan(p.delbeta[i]) || isinf(p.delbeta[i])
+            p.delbeta[i] = 0
+        end
+    end
     mul!(out, p.X, iszero(f) ? p.beta0 : broadcast!(muladd, p.scratchbeta, f, p.delbeta, p.beta0))
 end
 
@@ -126,12 +131,12 @@ function cholesky(p::DensePredChol{T}) where T<:FP
 end
 cholesky!(p::DensePredQR{T}) where {T<:FP} = Cholesky{T,typeof(p.X)}(p.qr.R, 'U', 0)
 
-function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}) where T<:BlasReal
+function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}; allowrankdeficient::Bool=false) where T<:BlasReal
     ldiv!(p.chol, mul!(p.delbeta, transpose(p.X), r))
     p
 end
 
-function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}) where T<:BlasReal
+function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}; allowrankdeficient::Bool=false) where T<:BlasReal
     ch = p.chol
     delbeta = mul!(p.delbeta, adjoint(p.X), r)
     rnk = rank(ch)
@@ -148,7 +153,7 @@ function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}) where T<:
     p
 end
 
-function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}, wt::Vector{T}) where T<:BlasReal
+function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}, wt::Vector{T}; allowrankdeficient::Bool=false) where T<:BlasReal
     scr = mul!(p.scratchm1, Diagonal(wt), p.X)
     cholesky!(Hermitian(mul!(cholfactors(p.chol), transpose(scr), p.X), :U))
     mul!(p.delbeta, transpose(scr), r)
@@ -156,11 +161,16 @@ function delbeta!(p::DensePredChol{T,<:Cholesky}, r::Vector{T}, wt::Vector{T}) w
     p
 end
 
-function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}, wt::Vector{T}) where T<:BlasReal
+function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}, wt::Vector{T}; allowrankdeficient::Bool=false) where T<:BlasReal
     cf = cholfactors(p.chol)
     piv = p.chol.piv
     cf .= mul!(p.scratchm2, adjoint(LinearAlgebra.mul!(p.scratchm1, Diagonal(wt), p.X)), p.X)[piv, piv]
-    cholesky!(Hermitian(cf, Symbol(p.chol.uplo)))
+    if allowrankdeficient
+        cholesky!(Hermitian(cf, Symbol(p.chol.uplo)),
+                  Val(true), tol = -one(T), check = false)
+    else
+        cholesky!(Hermitian(cf, Symbol(p.chol.uplo)))
+    end
     ldiv!(p.chol, mul!(p.delbeta, transpose(p.scratchm1), r))
     p
 end
@@ -185,9 +195,15 @@ function SparsePredChol(X::SparseMatrixCSC{T}) where T
         similar(X))
 end
 
-cholpred(X::SparseMatrixCSC) = SparsePredChol(X)
+function cholpred(X::SparseMatrixCSC, pivot::Bool=false)
+    if pivot
+        throw(ArgumentError("Pivoting sparse X is not yet supported"))
+    end
+    return SparsePredChol(X)
+end
 
-function delbeta!(p::SparsePredChol{T}, r::Vector{T}, wt::Vector{T}) where T
+function delbeta!(p::SparsePredChol{T}, r::Vector{T}, wt::Vector{T};
+                  allowrankdeficient::Bool = false) where T
     scr = mul!(p.scratch, Diagonal(wt), p.X)
     XtWX = p.Xt*scr
     c = p.chol = cholesky(Symmetric{eltype(XtWX),typeof(XtWX)}(XtWX, 'L'))


### PR DESCRIPTION
This pull request supersedes #273, which is no longer mergeable.

Currently, GLM.jl has support for rank-deficient `LinearModel`. This pull request adds support for rank-deficient `GeneralizedLinearModel`.

My main use case is that I often find myself needing to fit a `GeneralizedLinearModel` (usually a logistic regression) on a `DataFrame` with linearly dependent feature columns.

cc: @Nosferican @nalimilan @jiahao @dmbates @andreasnoack  

Closes https://github.com/JuliaStats/GLM.jl/issues/262