### PR TITLE
Allow for StatsFuns 0.9 and prepare for new bugfix release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLM"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -24,7 +24,7 @@ RDatasets = "0.5, 0.6"
 Reexport = "0.1, 0.2"
 SpecialFunctions = "0.6, 0.7, 0.8"
 StatsBase = "0.30, 0.31, 0.32"
-StatsFuns = "0.6, 0.7, 0.8"
+StatsFuns = "0.6, 0.7, 0.8, 0.9"
 StatsModels = "0.6"
 julia = "1"
 


### PR DESCRIPTION
This is semi-urgent since StatsFuns didn't have an upper bound on SpecialFunctions in version 0.8 so some users are now experiencing breakages when SpecialFunctions and DiffRules are upgraded but StatsFuns is hold back.