### PR TITLE
null deviance and null loglikelihood for GLM

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -65,6 +65,26 @@ end
 
 deviance(r::GlmResp) = sum(r.devresid)
 
+function nulldeviance(r::GlmResp)
+    y = r.y
+    d = r.d
+    wts = r.wts
+    if isempty(r.wts)
+        mu = mean(y)
+        dv = 0.0 
+        for i in eachindex(y)
+            dv += devresid(d, y[i], mu)
+        end
+    else 
+        mu = mean(y, weights(wts))
+        dv = 0.0
+        for i in eachindex(y, wts)
+            dv += devresid(d, y[i], mu) * wts[i]
+        end
+    end
+    return dv
+end
+
 """
     cancancel(r::GlmResp{V,D,L})
 
@@ -243,6 +263,7 @@ function confint(obj::AbstractGLM; level::Real=0.95)
 end
 
 deviance(m::AbstractGLM) = deviance(m.rr)
+nulldeviance(m::AbstractGLM) = nulldeviance(m.rr)
 
 function loglikelihood(m::AbstractGLM)
     r   = m.rr

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -71,13 +71,13 @@ function nulldeviance(r::GlmResp)
     wts = r.wts
     if isempty(r.wts)
         mu = mean(y)
-        dv = 0.0 
+        dv = zero(mu) 
         for i in eachindex(y)
             dv += devresid(d, y[i], mu)
         end
     else 
         mu = mean(y, weights(wts))
-        dv = 0.0
+        dv = zero(mu)
         for i in eachindex(y, wts)
             dv += devresid(d, y[i], mu) * wts[i]
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,7 @@ dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
     test_show(gm1)
     @test dof(gm1) == 5
     @test isapprox(deviance(gm1), 5.12914107700115, rtol = 1e-7)
+    @test isapprox(nulldeviance(gm1), 10.581445863750867)
     @test isapprox(loglikelihood(gm1), -23.380659200978837, rtol = 1e-7)
     @test isapprox(aic(gm1), 56.76131840195767)
     @test isapprox(aicc(gm1), 76.76131840195768)
@@ -118,10 +119,15 @@ admit.rank = categorical(admit.rank)
 
 @testset "$distr with LogitLink" for distr in (Binomial, Bernoulli)
     gm2 = fit(GeneralizedLinearModel, @formula(admit ~ 1 + gre + gpa + rank), admit, distr())
+    glmR = R"""
+        m = glm(Cadmit ~ 1 + gre + gpa + rank, family = binomial, data = $admit)
+        m[["null.deviance"]]
+    """    
     @test GLM.cancancel(gm2.model.rr)
     test_show(gm2)
     @test dof(gm2) == 6
     @test deviance(gm2) ≈ 458.5174924758994
+    @test isapprox(nulldeviance(gm2), 499.976517554917)
     @test loglikelihood(gm2) ≈ -229.25874623794968
     @test isapprox(aic(gm2), 470.51749247589936)
     @test isapprox(aicc(gm2), 470.7312329339146)
@@ -138,6 +144,7 @@ end
     @test !GLM.cancancel(gm3.model.rr)
     @test dof(gm3) == 6
     @test isapprox(deviance(gm3), 458.4131713833386)
+    @test isapprox(nulldeviance(gm3), 499.976517554917)
     @test isapprox(loglikelihood(gm3), -229.20658569166932)
     @test isapprox(aic(gm3), 470.41317138333864)
     @test isapprox(aicc(gm3), 470.6269118413539)
@@ -146,7 +153,7 @@ end
         [-2.3867922998680777, 0.0013755394922972401, 0.47772908362646926,
         -0.4154125854823675, -0.8121458010130354, -0.9359047862425297])
 end
-
+# end here
 @testset "Bernoulli CauchitLink" begin
     gm4 = fit(GeneralizedLinearModel, @formula(admit ~ gre + gpa + rank), admit,
               Binomial(), CauchitLink())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -277,7 +277,7 @@ clotting = DataFrame(u = log.([5,10,15,20,30,40,60,80,100]),
     @test isapprox(GLM.dispersion(gm8.model, true), 0.002446059333495581, atol=1e-6)
     @test isapprox(stderror(gm8), [0.00092754223, 0.000414957683], atol=1e-6)
 end
-# end here
+
 @testset "InverseGaussian" begin
     gm8a = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, InverseGaussian())
     nulldevianceR = R"""
@@ -433,6 +433,7 @@ end
 end
 
 # TODO: Understand how negative binomail works here
+# end here
 @rlibrary MASS
 # "quine" dataset discussed in Section 7.4 of "Modern Applied Statistics with S"
 quine = dataset("MASS", "quine")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,12 +161,13 @@ end
     test_show(gm4)
     @test dof(gm4) == 6
     @test isapprox(deviance(gm4), 459.3401112751141)
+    @test isapprox(nulldeviance(gm4), 499.976517554917)
     @test isapprox(loglikelihood(gm4), -229.6700556375571)
     @test isapprox(aic(gm4), 471.3401112751142)
     @test isapprox(aicc(gm4), 471.5538517331295)
     @test isapprox(bic(gm4), 495.28889855776214)
 end
-
+# here
 @testset "Bernoulli CloglogLink" begin
     gm5 = fit(GeneralizedLinearModel, @formula(admit ~ gre + gpa + rank), admit,
               Binomial(), CloglogLink())


### PR DESCRIPTION
This is a commit to fix #256, noting that GLM is without a null deviance or null log likelihood function. It's important to have this because likelihood ratio tests and R^2 use null deviance. 

I am not 100% if this is correct. So far my results match R's `glm` with `gaussian()` and `binomial()` families, but to be honest I am still taking econometrics courses so my knowledge of this is slim. 

I will add `nullloglikelihood` next, then tests for everything I can, then add `r2` functions and anything else that might use them. 

