### PR TITLE
Add confidence intervals for GLM predictions

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -533,7 +533,8 @@ function predict(mm::AbstractGLM, newX::AbstractMatrix;
         # Use Delta method to estimate variance in two steps
         # 1. Estimate variance for eta based on variance for coefficients
         #    through the diagonal of newX*vcov(mm)*newX'
-        vareta =  dot.(eachrow(newX), eachcol(vcov(mm)*newX'))
+        vcovXnewT = vcov(mm)*newX'
+        vareta = [dot(view(newX, i, :), view(vcovXnewT, :, i)) for i in axes(newX,1)]
         # 2. Now compute the variance for mu based on variance of eta
         varmu = vareta .* [abs2(mueta(Link(mm), x)) for x in eta]
     else

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -540,7 +540,7 @@ function predict(mm::AbstractGLM, newX::AbstractMatrix;
         return mu
     elseif interval == :confidence
         normalquantile = quantile(Normal(), (1 + level)/2)
-        # Estimate variance in two steps
+        # Compute confidence intervals in two steps
         # (2nd step varies depending on `interval_method`)
         # 1. Estimate variance for eta based on variance for coefficients
         #    through the diagonal of newX*vcov(mm)*newX'

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -511,11 +511,12 @@ end
             interval::Union{Symbol,Nothing}=nothing, level::Real = 0.95,
             interval_method::Symbol = :transformation)
 
-If `interval` is `nothing` (the default), return the predicted response of model
-`mm` from covariate values `newX` and, optionally, an `offset`. If `interval` is
-`:confidence`, also return upper and lower bounds for a given coverage `level`. By default
-(`interval_method = :transformation`) the intervals are constructed by applying the
-inverse link to intervals for the linear predictor. If `interval_method = :delta`,
+Return the predicted response of model `mm` from covariate values `newX` and,
+optionally, an `offset`.
+
+If `interval=:confidence`, also return upper and lower bounds for a given coverage `level`.
+By default (`interval_method = :transformation`) the intervals are constructed by applying
+the inverse link to intervals for the linear predictor. If `interval_method = :delta`,
 the intervals are constructed by the delta method, i.e., by linearization of the predicted
 response around the linear predictor. The `:delta` method intervals are symmetric around
 the point estimates, but do not respect natural parameter constraints
@@ -558,10 +559,10 @@ function predict(mm::AbstractGLM, newX::AbstractMatrix;
             lower = linkinv.(Link(mm), eta .- normalquantile .* stdeta)
             upper = linkinv.(Link(mm), eta .+ normalquantile .* stdeta)
         else
-            error("interval_method can be only :transformation or :delta")
+            throw(ArgumentError("interval_method can be only :transformation or :delta"))
         end
     else
-        error("only :confidence intervals are defined")
+        throw(ArgumentError("only :confidence intervals are defined"))
     end
     (prediction = mu, lower = lower, upper = upper)
 end

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -515,7 +515,7 @@ If `interval` is `nothing` (the default), return the predicted response of model
 `mm` from covariate values `newX` and, optionally, an `offset`. If `interval` is
 `:confidence`, also return upper and lower bounds for a given coverage `level`. By 
 default (`symmetric = false`) the intervals are constructed by applying the inverse link
-to intervals for the linear predictor, if `symmetric=true`, the intervals are symmetric 
+to intervals for the linear predictor. If `symmetric=true`, the intervals are symmetric 
 around the point estimates.
 """
 function predict(mm::AbstractGLM, newX::AbstractMatrix;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,8 +459,8 @@ end
     newX = rand(5, 2)
     newY = logistic.(newX * coef(gm11))
     gm11_pred1 = predict(gm11, newX)
-    gm11_pred2 = predict(gm11, newX; interval=:confidence, symmetric=true)
-    gm11_pred3 = predict(gm11, newX; interval=:confidence, symmetric=false)
+    gm11_pred2 = predict(gm11, newX; interval=:confidence, interval_method=:delta)
+    gm11_pred3 = predict(gm11, newX; interval=:confidence, interval_method=:transformation)
     @test gm11_pred1 == gm11_pred2.prediction == gm11_pred3.prediction≈ newY
     se_pred = [0.19904587484129196, 0.18029108261296775,
                0.3290573571361879, 0.11536024793564569, 0.23972290956210984]
@@ -525,15 +525,16 @@ end
 
     R_glm_se = [0.09748766, 0.09808412, 0.07963897, 0.07495792, 0.05177654]
 
-    preds_asymmetric = predict(gm, newX, interval=:confidence, symmetric=false)
-    preds_symmetric = predict(gm, newX, interval=:confidence, symmetric=true)
+    preds_transformation = predict(gm, newX, interval=:confidence, interval_method=:transformation)
+    preds_delta = predict(gm, newX, interval=:confidence, interval_method=:delta)
 
-    @test preds_asymmetric.prediction == preds_symmetric.prediction
-    @test preds_asymmetric.prediction ≈ ggplot_prediction atol=1e-3
-    @test preds_asymmetric.lower ≈ ggplot_lower atol=1e-3
-    @test preds_asymmetric.upper ≈ ggplot_upper atol=1e-3
+    @test preds_transformation.prediction == preds_delta.prediction
+    @test preds_transformation.prediction ≈ ggplot_prediction atol=1e-3
+    @test preds_transformation.lower ≈ ggplot_lower atol=1e-3
+    @test preds_transformation.upper ≈ ggplot_upper atol=1e-3
 
-    @test preds_symmetric.upper .-  preds_symmetric.lower ≈ 2 .* 1.96 .* R_glm_se atol=1e-3
+    @test preds_delta.upper .-  preds_delta.lower ≈ 2 .* 1.96 .* R_glm_se atol=1e-3
+    @test_throws ErrorException predict(gm, newX, interval=:confidence, interval_method=:undefined_method)
 end 
 
 @testset "F test for model comparison" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -534,7 +534,8 @@ end
     @test preds_transformation.upper ≈ ggplot_upper atol=1e-3
 
     @test preds_delta.upper .-  preds_delta.lower ≈ 2 .* 1.96 .* R_glm_se atol=1e-3
-    @test_throws ErrorException predict(gm, newX, interval=:confidence, interval_method=:undefined_method)
+    @test_throws ArgumentError predict(gm, newX, interval=:confidence, interval_method=:undefined_method)
+    @test_throws ArgumentError predict(gm, newX, interval=:undefined)
 end 
 
 @testset "F test for model comparison" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,8 +463,8 @@ end
     gm11_pred3 = predict(gm11, newX; interval=:confidence, symmetric=false)
     @test gm11_pred1 == gm11_pred2.prediction == gm11_pred3.prediction≈ newY
     se_pred = [0.19904587484129196, 0.18029108261296775,
-                   0.3290573571361879, 0.11536024793564569, 0.23972290956210984]
-    @test gm11_pred2.lower ≈ gm11_pred2.prediction .- quantile(Normal(), 0.975).*se_pred #
+               0.3290573571361879, 0.11536024793564569, 0.23972290956210984]
+    @test gm11_pred2.lower ≈ gm11_pred2.prediction .- quantile(Normal(), 0.975).*se_pred
     @test gm11_pred2.upper ≈ gm11_pred2.prediction .+ quantile(Normal(), 0.975).*se_pred
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -458,7 +458,14 @@ end
 
     newX = rand(5, 2)
     newY = logistic.(newX * coef(gm11))
-    @test isapprox(predict(gm11, newX), newY)
+    gm11_pred1 = predict(gm11, newX)
+    gm11_pred2 = predict(gm11, newX; interval=:confidence)
+    @test gm11_pred1 == gm11_pred2.prediction ≈ newY
+    se_pred = [0.19904587484129196, 0.18029108261296775,
+                   0.3290573571361879, 0.11536024793564569, 0.23972290956210984]
+    @test gm11_pred2.lower ≈ gm11_pred2.prediction .- quantile(Normal(), 0.975).*se_pred #
+    @test gm11_pred2.upper ≈ gm11_pred2.prediction .+ quantile(Normal(), 0.975).*se_pred
+
 
     off = rand(10)
     newoff = rand(5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -534,10 +534,6 @@ end
     @test preds_asymmetric.upper ≈ ggplot_upper atol=1e-3
 
     @test preds_symmetric.upper .-  preds_symmetric.lower ≈ 2 .* 1.96 .* R_glm_se atol=1e-3
-
-    # now fit model at level so that CI width is equal to standard error
-    preds_symmetric_at_se =  predict(gm, newX, interval=:confidence, symmetric=true, level=0.3829249)
-    @test preds_symmetric_at_se.upper .-  preds_symmetric_at_se.lower ≈  R_glm_se atol=1e-3
 end 
 
 @testset "F test for model comparison" begin


### PR DESCRIPTION
As per the title. I tried to follow the interface of the `predict` function for linear models. Note that for GLMs `:prediction` intervals do not make sense in general; `:confidence` intervals however do.

R's `predict.glm` does not provide intervals, but it can calculate the standard error of the predictions through the `se.fit` option. The intervals in this PR are calculated based on a Normal approximation and the standard error of the predictions is calculated as in R (through the Delta method).

Fixes #101.