### PR TITLE
Allow version 0.6 of CSV

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
-CSV = "0.5"
+CSV = "0.5, 0.6"
 CategoricalArrays = "0.3, 0.4, 0.5, 0.6, 0.7"
 DataFrames = "0.19, 0.20"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"


### PR DESCRIPTION
Not sure why CompatHelper didn't handle this one. Possibly because it's just a test dependency. cc @DilumAluthge 