### PR TITLE
convert all eltypes of GlmResp args to the eltype of the first

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -60,7 +60,9 @@ end
 
 function GlmResp(y::AbstractVector{<:Real}, d::D, l::L, off::AbstractVector{<:Real}, 
                  wts::AbstractVector{<:Real}) where {D, L}
-        GlmResp(float(y), d, l, float(off), float(wts))
+        yt = float(y)
+        T = eltype(yt)
+        GlmResp(T.(y), d, l, T.(off), T.(wts))
 end
 
 deviance(r::GlmResp) = sum(r.devresid)


### PR DESCRIPTION
min example: `GLM.GlmResp(randn(10), Binomial(), LogitLink(), randn(Float32, 10), randn(10))` Gets stuck in a loop because `float` won't convert `Float64` and `Float32` to the same type. I just turned the first one into a float, and then made the rest match that type of float explicitly.