### PR TITLE
import/export fitted

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,12 +12,12 @@ module GLM
     import Statistics: cor
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
                       loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-                      fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue
+                      fitted, fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv, digamma, trigamma
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-           fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²
+           fitted, fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²
 
     export
         # types

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,7 +447,6 @@ end
     @test isapprox(vcov(gmsparse), vcov(gmdense))
 end
 
-
 @testset "Predict" begin
     Random.seed!(1)
     X = rand(10, 2)
@@ -455,7 +454,8 @@ end
 
     gm11 = fit(GeneralizedLinearModel, X, Y, Binomial())
     @test isapprox(predict(gm11), Y)
-
+    @test predict(gm11) == fitted(gm11)
+    
     newX = rand(5, 2)
     newY = logistic.(newX * coef(gm11))
     @test isapprox(predict(gm11, newX), newY)


### PR DESCRIPTION
`fitted` is defined in StatsBase.jl, and a method is defined in GLM.jl, but
`fitted` is not imported, and it's also not exported (as far as I can tell).
This PR just imports/exports `fitted` and adds one test to check that the method
resolves correctly and produces the same value as `predict(::LinPredModel)` (as
defined).