### PR TITLE
Fix predict with collinear=true

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -138,12 +138,12 @@ function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}) where T<:
     if rnk == length(delbeta)
         ldiv!(ch, delbeta)
     else
-        permute!(delbeta, ch.piv)
+        permute!(delbeta, ch.p)
         for k=(rnk+1):length(delbeta)
             delbeta[k] = -zero(T)
         end
         LAPACK.potrs!(ch.uplo, view(ch.factors, 1:rnk, 1:rnk), view(delbeta, 1:rnk))
-        invpermute!(delbeta, ch.piv)
+        invpermute!(delbeta, ch.p)
     end
     p
 end
@@ -158,7 +158,7 @@ end
 
 function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}, wt::Vector{T}) where T<:BlasReal
     cf = cholfactors(p.chol)
-    piv = p.chol.piv
+    piv = p.chol.p
     cf .= mul!(p.scratchm2, adjoint(LinearAlgebra.mul!(p.scratchm1, Diagonal(wt), p.X)), p.X)[piv, piv]
     cholesky!(Hermitian(cf, Symbol(p.chol.uplo)))
     ldiv!(p.chol, mul!(p.delbeta, transpose(p.scratchm1), r))
@@ -209,7 +209,7 @@ function invchol(x::DensePredChol{T,<: CholeskyPivoted}) where T
         res[i, j] = fac[i, j]
     end
     copytri!(LAPACK.potri!(ch.uplo, view(res, 1:rnk, 1:rnk)), ch.uplo, true)
-    ipiv = invperm(ch.piv)
+    ipiv = invperm(ch.p)
     res[ipiv, ipiv]
 end
 invchol(x::SparsePredChol) = cholesky!(x) \ Matrix{Float64}(I, size(x.X, 2), size(x.X, 2))

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -224,7 +224,9 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
         return retmean
     end
     length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
-    R = cholesky!(mm.pp).U #get the R matrix from the QR factorization
+    chol = cholesky!(mm.pp)
+    # get the R matrix from the QR factorization
+    R = chol isa CholeskyPivoted ? chol.U[chol.piv, chol.piv] : chol.U
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     if interval == :confidence
         retvariance = (newx/R).^2 * residvar

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -226,7 +226,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
     length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
     chol = cholesky!(mm.pp)
     # get the R matrix from the QR factorization
-    R = chol isa CholeskyPivoted ? chol.U[chol.piv, chol.piv] : chol.U
+    R = chol isa CholeskyPivoted ? chol.U[chol.p, chol.p] : chol.U
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     if interval == :confidence
         retvariance = (newx/R).^2 * residvar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -524,6 +524,21 @@ end
         0.18660252681017786, -1.6922982042879862, -0.46793127827646197]
     @test pred3.upper ≈ [3.9036197999106674, 2.6291976809914988,
         4.815559090394707, 2.3612485765861515, 3.8867779526777784]
+
+    # Prediction with dropcollinear (#409)
+    x = [1.0 1.0
+         1.0 2.0
+         1.0 -1.0]
+    y = [1.0, 3.0, -2.0]
+    m1 = lm(x, y, dropcollinear=true)
+    m2 = lm(x, y, dropcollinear=false)
+
+    p1 = predict(m1, x, interval=:confidence)
+    p2 = predict(m2, x, interval=:confidence)
+
+    @test p1.prediction ≈ p2.prediction
+    @test p1.upper ≈ p2.upper
+    @test p1.lower ≈ p2.lower
 end
 
 @testset "GLM confidence intervals" begin


### PR DESCRIPTION
We need to reorder rows and columns when using pivoted Cholesky decomposition.

Fixes #409.