### PR TITLE
Verbose show with R² and F-statistic

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -227,13 +227,11 @@ function show(io::IO, obj::LinPredModel)
     println(io, "$(typeof(obj)):\n\nCoefficients:\n", coeftable(obj))
 end
 
-modelframe(obj::LinPredModel) = obj.fr
 modelmatrix(obj::LinPredModel) = obj.pp.X
 response(obj::LinPredModel) = obj.rr.y
 
 fitted(m::LinPredModel) = m.rr.mu
 predict(mm::LinPredModel) = fitted(mm)
-formula(obj::LinPredModel) = modelframe(obj).formula
 residuals(obj::LinPredModel) = residuals(obj.rr)
 
 """


### PR DESCRIPTION
Adds R² and F-statistic, bringing the output closer to what users might expect when coming from R.

Example:

```
julia> ols_lin.model
LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}}}}

Coefficients:
─────────────────────────────────────────────────────────────
     Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
─────────────────────────────────────────────────────────────
x1  -442.0     54.5539  -8.10    <1e-09  -551.688   -332.312
x2    51.0      1.8619  27.39    <1e-30    47.2564    54.7436
─────────────────────────────────────────────────────────────

R² = 0.9399
F-statistic: 750.3 on 1 and 50 degrees of freedom, p-value: 0.02898
```

