### PR TITLE
Update the perf script.

### DIFF
--- a/perf/glm.jl
+++ b/perf/glm.jl
@@ -1,21 +1,23 @@
-using GLM, DataFrames, StatsFuns
-glm(@formula(y ~ 1), DataFrame(y = float(bitrand(10))), Bernoulli())
-
+using GLM, Random, StatsModels
+                                # create a column table with dummy response
 n = 2_500_000
-Random.seed!(1234321)
-const df2 = DataFrame(x1 = rand(Normal(), n),
-                x2 = rand(Exponential(), n),
-                ss = pool(rand(DiscreteUniform(50), n)));
-const mf = ModelFrame(@formula(x1 ~ x1 + x2 + ss), df2)
-const mm = ModelMatrix(mf)
-const β = pushfirst!(rand(Normal(),52), 0.5); # "true" parameter values
-
-## Create linear predictor and mean response
-
-const y = [float(rand() < logistic(η)) for η in mm.m * β];        # simulate observed responses
-
-gm6 = glm(mm.m, y, Bernoulli())
-@time glm(mm.m, y, Bernoulli());
-#@profile glm(mm.m, y, Binomial());
-#using ProfileView
-#ProfileView.view()
+rng = MersenneTwister(1234321)
+tbl = (
+    x1 = randn(rng, n),
+    x2 = Random.randexp(rng, n),
+    ss = rand(rng, string.(50:99), n),
+    y = zeros(n),
+)
+                                # apply a formula to create a model matrix
+f = @formula(y ~ 1 + x1 + x2 + ss)
+f = apply_schema(f, schema(f, tbl))
+resp, pred = modelcols(f, tbl)
+                                # simulate β and the response
+β = randn(rng, size(pred, 2))
+β[1] = 0.5        # to avoid edge cases
+logistic(x::Real) = inv(1 + exp(-x))
+resp .= rand(rng, n) .< logistic.(pred * β)
+                                # fit a subset of the data
+gm6 = glm(pred[1:1000, :], resp[1:1000], Bernoulli())
+                                # time the fit on the whole data set
+@time glm(pred, resp, Bernoulli());


### PR DESCRIPTION
The perf/glm.jl script was using out-of-date constructions.  This includes updates to recent versions of the Random and StatsModels packages.  It turns out that most of the effort in fitting a large-ish Bernoulli model like this is in the linear algebra.  Using Julia v1.7.0-DEV just switching to MKL saves about 30% of the fitting time on my laptop.
```julia
julia> @time glm(pred, resp, Bernoulli());
  4.994811 seconds (46.76 k allocations: 2.052 GiB, 2.71% gc time, 0.44% compilation time)

julia> using MKL

julia> @time glm(pred, resp, Bernoulli());
  3.549232 seconds (40 allocations: 2.049 GiB, 2.88% gc time)
```