### PR TITLE
Fix more `predict` confidence intervals when `dropcollinear=true`

### DIFF
--- a/src/lm.jl
+++ b/src/lm.jl
@@ -249,7 +249,12 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
     length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
     chol = cholesky!(mm.pp)
     # get the R matrix from the QR factorization
-    R = chol isa CholeskyPivoted ? chol.U[chol.p, chol.p] : chol.U
+    if chol isa CholeskyPivoted
+        ip = invperm(chol.p)
+        R = chol.U[ip, ip]
+    else
+        R = chol.U
+    end
     residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
     if interval == :confidence
         retvariance = (newx/R).^2 * residvar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -582,6 +582,22 @@ end
     @test p1.upper ≈ p2.upper
     @test p1.lower ≈ p2.lower
 
+    # Prediction with dropcollinear and complex column permutations (#431)
+    x = [1.0 100.0 1.2
+         1.0 20000.0 2.3
+         1.0 -1000.0 4.6
+         1.0 5000 2.4]
+    y = [1.0, 3.0, -2.0, 4.5]
+    m1 = lm(x, y, dropcollinear=true)
+    m2 = lm(x, y, dropcollinear=false)
+
+    p1 = predict(m1, x, interval=:confidence)
+    p2 = predict(m2, x, interval=:confidence)
+
+    @test p1.prediction ≈ p2.prediction
+    @test p1.upper ≈ p2.upper
+    @test p1.lower ≈ p2.lower
+
     # Deprecated argument value
     @test predict(m1, x, interval=:confint) == p1
 end


### PR DESCRIPTION
The previous fix (https://github.com/JuliaStats/GLM.jl/pull/410) handled incorreclty cases where pivoted Cholesky decomposition permutes columns in a non-monotonous way. This is because the inverted permutation has to be used, but that bug isn't visible in simple examples.

Fixes https://github.com/JuliaStats/GLM.jl/issues/431.