### PR TITLE
Throw an error in `predict` with intervals for rank-deficient models

### DIFF
--- a/src/lm.jl
+++ b/src/lm.jl
@@ -245,6 +245,11 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
     end
     if interval === nothing
         return retmean
+    elseif mm.pp.chol isa CholeskyPivoted &&
+        mm.pp.chol.rank < size(mm.pp.chol, 2)
+        throw(ArgumentError("prediction intervals are currently not implemented " *
+                            "when some independent variables have been dropped " *
+                            "from model due to collinearity"))
     end
     length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
     chol = cholesky!(mm.pp)

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -249,7 +249,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
         mm.pp.chol.rank < size(mm.pp.chol, 2)
         throw(ArgumentError("prediction intervals are currently not implemented " *
                             "when some independent variables have been dropped " *
-                            "from model due to collinearity"))
+                            "from the model due to collinearity"))
     end
     length(mm.rr.wts) == 0 || error("prediction with confidence intervals not yet implemented for weighted regression")
     chol = cholesky!(mm.pp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -605,7 +605,7 @@ end
     # have been dropped due to collinearity (#410)
     x = [1.0 1.0 2.0
          1.0 2.0 3.0
-         1.0 -1.0 0.0];
+         1.0 -1.0 0.0]
     y = [1.0, 3.0, -2.0]
     m1 = lm(x, y)
     m2 = lm(x[:, 1:2], y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -600,6 +600,23 @@ end
 
     # Deprecated argument value
     @test predict(m1, x, interval=:confint) == p1
+
+    # Prediction intervals would give incorrect results when some variables
+    # have been dropped due to collinearity (#410)
+    x = [1.0 1.0 2.0
+         1.0 2.0 3.0
+         1.0 -1.0 0.0];
+    y = [1.0, 3.0, -2.0]
+    m1 = lm(x, y)
+    m2 = lm(x[:, 1:2], y)
+
+    @test predict(m1) ≈ predict(m2)
+    @test_broken predict(m1, interval=:confidence) ≈
+        predict(m2, interval=:confidence)
+    @test_broken predict(m1, interval=:prediction) ≈
+        predict(m2, interval=:prediction)
+    @test_throws ArgumentError predict(m1, x, interval=:confidence)
+    @test_throws ArgumentError predict(m1, x, interval=:prediction)
 end
 
 @testset "GLM confidence intervals" begin


### PR DESCRIPTION
`predict` currently gives incorrect intervals when some variables have been dropped due to collinearity. Throw an error instead to
avoid misleading users, until we find a fix.

See https://github.com/JuliaStats/GLM.jl/pull/410#issuecomment-793920775.