### PR TITLE
Docs for not using a DataFrame

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -44,6 +44,42 @@ julia> round.(predict(ols), digits=5)
  6.83333
 ```
 
+### Without DataFrame
+Because a named tuple follows common table-interface defined in `Tables.jl` 
+(which is the one followed by a DataFrame), the problem can also be specified 
+with data in a named tuple as opposed to a `DataFrame`:
+```jldoctetst
+julia> using GLM
+
+julia> X=[1,2,3]
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+
+julia> Y=[2,4,7]
+3-element Vector{Int64}:
+ 2
+ 4
+ 7
+
+julia> data = (;X, Y)  # Equivalent to (X=X, Y=Y)
+(X = [1, 2, 3], Y = [2, 4, 7])
+
+julia> lm(@formula(Y~X), data)
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}}}}, Matrix{Float64}}
+
+Y ~ 1 + X
+
+Coefficients:
+─────────────────────────────────────────────────────────────────────────
+                 Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
+─────────────────────────────────────────────────────────────────────────
+(Intercept)  -0.666667    0.62361   -1.07    0.4788   -8.59038    7.25704
+X             2.5         0.288675   8.66    0.0732   -1.16797    6.16797
+─────────────────────────────────────────────────────────────────────────
+```
+
 ## Probit regression
 ```jldoctest
 julia> data = DataFrame(X=[1,2,2], Y=[1,0,1])


### PR DESCRIPTION
This PR adds documentation on how to do a fit without using a DataFrame, as suggested by @pdeffebach in [this thread](https://discourse.julialang.org/t/the-simplest-linear-fit-with-glm/71316/11).