### PR TITLE
Fix `coeftable` for saturated linear models

### DIFF
--- a/src/lm.jl
+++ b/src/lm.jl
@@ -215,10 +215,18 @@ end
 
 function coeftable(mm::LinearModel; level::Real=0.95)
     cc = coef(mm)
-    se = stderror(mm)
-    tt = cc ./ se
-    p = ccdf.(Ref(FDist(1, dof_residual(mm))), abs2.(tt))
-    ci = se*quantile(TDist(dof_residual(mm)), (1-level)/2)
+    dofr = dof_residual(mm)
+    if dofr > 0
+        se = stderror(mm)
+        tt = cc ./ se
+        p = ccdf.(Ref(FDist(1, dof_residual(mm))), abs2.(tt))
+        ci = se*quantile(TDist(dof_residual(mm)), (1-level)/2)
+    else
+        se = fill(NaN, length(cc))
+        tt = fill(NaN, length(cc))
+        p = fill(NaN, length(cc))
+        ci = fill(NaN, length(cc))
+    end
     levstr = isinteger(level*100) ? string(Integer(level*100)) : string(level*100)
     CoefTable(hcat(cc,se,tt,p,cc+ci,cc-ci),
               ["Coef.","Std. Error","t","Pr(>|t|)","Lower $levstr%","Upper $levstr%"],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,37 @@ end
     @test isapprox(coef(m2p_dep_pos_kw), coef(m2p))
 end
 
+@testset "saturated linear model" begin
+    df = DataFrame(x=["a", "b", "c"], y=[1, 2, 3])
+    model = lm(@formula(y ~ x), df)
+    ct = coeftable(model)
+    @test dof_residual(model) == 0
+    @test dof(model) == 4
+    @test coef(model) ≈ [1, 1, 2]
+    @test all(isnan, hcat(ct.cols[2:end]...))
+
+    model = lm(@formula(y ~ 0 + x), df)
+    ct = coeftable(model)
+    @test dof_residual(model) == 0
+    @test dof(model) == 4
+    @test coef(model) ≈ [1, 2, 3]
+    @test all(isnan, hcat(ct.cols[2:end]...))
+
+    model = glm(@formula(y ~ x), df, Normal(), IdentityLink())
+    ct = coeftable(model)
+    @test dof_residual(model) == 0
+    @test dof(model) == 4
+    @test coef(model) ≈ [1, 1, 2]
+    @test all(isnan, hcat(ct.cols[2:end]...))
+
+    model = glm(@formula(y ~ 0 + x), df, Normal(), IdentityLink())
+    ct = coeftable(model)
+    @test dof_residual(model) == 0
+    @test dof(model) == 4
+    @test coef(model) ≈ [1, 2, 3]
+    @test all(isnan, hcat(ct.cols[2:end]...))
+end
+
 dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
     Outcome = categorical(repeat(string.('A':'C'), outer = 3)),
     Treatment = categorical(repeat(string.('a':'c'), inner = 3)))


### PR DESCRIPTION
`coeftable` failed for saturated `LinearModel`s due to trying to compute F and T distributions with zero DOF.

Fixes #456.