### PR TITLE
use `StatsModels.isnested` instead of defining new `issubmodel` func

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,7 +65,7 @@ StatsBase.deviance
 GLM.dispersion
 GLM.ftest
 GLM.installbeta!
-GLM.issubmodel
+StatsModels.isnested
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,10 +65,10 @@ StatsBase.deviance
 GLM.dispersion
 GLM.ftest
 GLM.installbeta!
-StatsModels.isnested
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict
+StatsModels.isnested
 ```
 
 ## Links and methods applied to them

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -14,8 +14,10 @@ mutable struct FTestResult{N}
     pval::NTuple{N, Float64}
 end
 
+@deprecate issubmodel(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0) StatsModels.isnested(mod1, mod2; atol)
+
 """A helper function to determine if mod1 is nested in mod2"""
-function issubmodel(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0)
+function StatsModels.isnested(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0)
     mod1.rr.y != mod2.rr.y && return false # Response variables must be equal
 
     # Test that models are nested
@@ -136,13 +138,13 @@ function ftest(mods::LinearModel...; atol::Real=0.0)
     forward = length(mods) == 1 || dof(mods[1]) <= dof(mods[2])
     if forward
         for i in 2:length(mods)
-            if dof(mods[i-1]) >= dof(mods[i]) || !issubmodel(mods[i-1], mods[i], atol=atol)
+            if dof(mods[i-1]) >= dof(mods[i]) || !StatsModels.isnested(mods[i-1], mods[i], atol=atol)
                 throw(ArgumentError("F test is only valid for nested models"))
             end
         end
     else
         for i in 2:length(mods)
-            if dof(mods[i]) >= dof(mods[i-1]) || !issubmodel(mods[i], mods[i-1], atol=atol)
+            if dof(mods[i]) >= dof(mods[i-1]) || !StatsModels.isnested(mods[i], mods[i-1], atol=atol)
                 throw(ArgumentError("F test is only valid for nested models"))
             end
         end

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -16,7 +16,6 @@ end
 
 @deprecate issubmodel(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0) StatsModels.isnested(mod1, mod2; atol=atol)
 
-"""A helper function to determine if mod1 is nested in mod2"""
 function StatsModels.isnested(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0)
     mod1.rr.y != mod2.rr.y && return false # Response variables must be equal
 

--- a/src/ftest.jl
+++ b/src/ftest.jl
@@ -14,7 +14,7 @@ mutable struct FTestResult{N}
     pval::NTuple{N, Float64}
 end
 
-@deprecate issubmodel(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0) StatsModels.isnested(mod1, mod2; atol)
+@deprecate issubmodel(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0) StatsModels.isnested(mod1, mod2; atol=atol)
 
 """A helper function to determine if mod1 is nested in mod2"""
 function StatsModels.isnested(mod1::LinPredModel, mod2::LinPredModel; atol::Real=0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -708,15 +708,15 @@ end
     othermod = lm(@formula(Result~Other), d).model
     nullmod = lm(@formula(Result~1), d).model
     bothmod = lm(@formula(Result~Other+Treatment), d).model
-    @test GLM.issubmodel(nullmod, mod)
-    @test !GLM.issubmodel(othermod, mod)
-    @test GLM.issubmodel(mod, bothmod)
-    @test !GLM.issubmodel(bothmod, mod)
-    @test GLM.issubmodel(othermod, bothmod)
+    @test StatsModels.isnested(nullmod, mod)
+    @test !StatsModels.isnested(othermod, mod)
+    @test StatsModels.isnested(mod, bothmod)
+    @test !StatsModels.isnested(bothmod, mod)
+    @test StatsModels.isnested(othermod, bothmod)
 
     d.Sum = d.Treatment + (d.Other .== 1)
     summod = lm(@formula(Result~Sum), d).model
-    @test GLM.issubmodel(summod, bothmod)
+    @test StatsModels.isnested(summod, bothmod)
 
     ft1a = ftest(mod, nullmod)
     @test isnan(ft1a.pval[1])
@@ -851,7 +851,7 @@ end
     # Fit 2 (both)
     Xc2 = RL\X
     mod2 = lm(Xc2, Yc)
-    @test GLM.issubmodel(mod1, mod2)
+    @test StatsModels.isnested(mod1, mod2)
 end
 
 @testset "coeftable" begin


### PR DESCRIPTION
This just replaces the function called `issubmodel` with a method for `StatsModels.isnested` in order to provide support for `StatsModels.lrtest` and other goodies that assume that API.  `issubmodel` is deprecated and otherwise there are no changes to the code.

edit: I have not bumped the version.  I'll open a new PR for that once this is merged.