### PR TITLE
change version back to 1.6.0 since 1.6.0 was never released

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLM"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.6.1"
+version = "1.6.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
Fixes #463.  Neither 1.6.0 nor 1.6.1 were released so to tag a new release we should use 1.6.0.

Should wait on #462 (hence teh target branch)