### PR TITLE
support heterogeneous array types

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -49,11 +49,12 @@ function GlmResp(y::V, d::D, l::L, η::V, μ::V, off::V, wts::V) where {V<:FPVec
     return GlmResp{V,D,L}(y, d, similar(y), η, μ, off, wts, similar(y), similar(y))
 end
 
-function GlmResp(y::V, d::D, l::L, off::V, wts::V) where {V<:FPVector,D,L}
+function GlmResp(y::FPVector, d::D, l::L, off::FPVector, wts::FPVector) where {D,L}
     η   = similar(y)
     μ   = similar(y)
-    r   = GlmResp(y, d, l, η, μ, off, wts)
-    initialeta!(r.eta, d, l, y, wts, off)
+    V   = typeof(η)
+    r   = GlmResp(convert(V, y), d, l, η, μ, convert(V, off), convert(V, wts))
+    initialeta!(r.eta, d, l, r.y, r.wts, r.offset)
     updateμ!(r, r.eta)
     return r
 end

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -28,8 +28,12 @@ mutable struct LmResp{V<:FPVector} <: ModResp  # response in a linear model
     end
 end
 
-LmResp(y::FPVector, wts::FPVector=similar(y, 0)) = 
-    LmResp{typeof(y)}(fill!(similar(y), 0), similar(y, 0), wts, y)
+function LmResp(y::FPVector, wts::FPVector=similar(y, 0))
+    μ   = fill!(similar(y), 0)
+    off = similar(y, 0)
+    V   = typeof(μ)
+    LmResp{V}(μ, convert(V, off), convert(V, wts), convert(V, y))
+end
 
 LmResp(y::AbstractVector{<:Real}, wts::AbstractVector{<:Real}=similar(y, 0)) = 
     LmResp(float(y), float(wts))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -904,6 +904,36 @@ end
     Test.@inferred cholesky(GLM.DensePredQR{Float64}(X))
 end
 
+@testset "Issue 213" begin
+    x, y, w = rand(100, 2), rand(100), rand(100)
+    lm1 = lm(x, y)
+    lm2 = lm(x, view(y, :))
+    lm3 = lm(view(x, :, :), y)
+    lm4 = lm(view(x, :, :), view(y, :))
+    @test coef(lm1) ≈ coef(lm2) ≈ coef(lm3) ≈ coef(lm4)
+
+    lm5 = lm(x, y, wts=w)
+    lm6 = lm(x, view(y, :), wts=w)
+    lm7 = lm(view(x, :, :), y, wts=w)
+    lm8 = lm(view(x, :, :), view(y, :), wts=w)
+    lm9 = lm(x, y, wts=view(w, :))
+    lm10 = lm(x, view(y, :), wts=view(w, :))
+    lm11 = lm(view(x, :, :), y, wts=view(w, :))
+    lm12 = lm(view(x, :, :), view(y, :), wts=view(w, :))
+    @test coef(lm5) ≈ coef(lm6) ≈ coef(lm7) ≈ coef(lm8) ≈ coef(lm9) ≈ coef(lm10) ≈ coef(lm11) ≈ coef(lm12)
+
+    x, y, w = rand(100, 2), rand(Bool, 100), rand(100)
+    glm1 = glm(x, y, Binomial())
+    glm2 = glm(x, view(y, :), Binomial())
+    @test coef(glm1) ≈ coef(glm2)
+
+    glm3 = glm(x, y, Binomial(), wts=w)
+    glm4 = glm(x, view(y, :), Binomial(), wts=w)
+    glm5 = glm(x, y, Binomial(), wts=view(w, :))
+    glm6 = glm(x, view(y, :), Binomial(), wts=view(w, :))
+    @test coef(glm3) ≈ coef(glm4) ≈ coef(glm5) ≈ coef(glm6)
+end
+
 @testset "Issue 224" begin
     rng = StableRNG(1009)
     # Make X slightly ill conditioned to amplify rounding errors


### PR DESCRIPTION
Fix #213 

This simply performs a conversion step before building `GLMResp` or `LMResp` to make sure that all arrays have the same type before proceeding to construct the object.

It still does not allow to pass an abstract matrix as the first argument to `GLM.glm`, because of [this signature](https://github.com/JuliaStats/GLM.jl/blob/be96833e470b914cd68ba007b3e47d127357be54/src/glmfit.jl#L468), but I imagine that can be addressed separately.