### PR TITLE
fix predict docstring and remove trailing dim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLM"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -236,7 +236,7 @@ end
 
 If `interval` is `nothing` (the default), return a vector with the predicted values
 for model `mm` and new data `newx`.
-Otherwise, return a 3-column matrix with the prediction and
+Otherwise, return a vector with the predicted values as well as
 the lower and upper confidence bounds for a given `level` (0.95 equates alpha = 0.05).
 Valid values of `interval` are `:confidence` delimiting the  uncertainty of the
 predicted relationship, and `:prediction` delimiting estimated bounds for new data points.
@@ -265,7 +265,7 @@ function predict(mm::LinearModel, newx::AbstractMatrix;
     else
         R = chol.U
     end
-    residvar = (ones(size(newx,2),1) * deviance(mm)/dof_residual(mm))
+    residvar = ones(size(newx,2)) * deviance(mm)/dof_residual(mm)
     if interval == :confidence
         retvariance = (newx/R).^2 * residvar
     elseif interval == :prediction

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -236,7 +236,7 @@ end
 
 If `interval` is `nothing` (the default), return a vector with the predicted values
 for model `mm` and new data `newx`.
-Otherwise, return a vector with the predicted values as well as
+Otherwise, return a vector with the predicted values, as well as vectors with
 the lower and upper confidence bounds for a given `level` (0.95 equates alpha = 0.05).
 Valid values of `interval` are `:confidence` delimiting the  uncertainty of the
 predicted relationship, and `:prediction` delimiting estimated bounds for new data points.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,6 +541,15 @@ end
     @test gm11_pred2.upper ≈ gm11_pred2.prediction .+ quantile(Normal(), 0.975).*se_pred ≈
         [0.6813754418027714, 0.9516561735593941, 1.0370309285468602, 0.5950732511233356, 1.192883895763427]
 
+    @test ndims(gm11_pred1) == 1
+
+    @test ndims(gm11_pred2.prediction) == 1
+    @test ndims(gm11_pred2.upper) == 1
+    @test ndims(gm11_pred2.lower) == 1
+
+    @test ndims(gm11_pred3.prediction) == 1
+    @test ndims(gm11_pred3.upper) == 1
+    @test ndims(gm11_pred3.lower) == 1
 
     off = rand(rng, 10)
     newoff = rand(rng, 5)
@@ -575,6 +584,12 @@ end
         [0.5483482828723035, 0.3252331944785751, 0.6367574076909834, 0.34715818536935505, -0.41478974520958345]
     @test pred2.upper ≈ pred2.prediction + quantile(TDist(dof_residual(mm)), 0.975)*se_pred ≈
         [1.7280792799868907, 2.0941782144792835, 2.9598617282413455, 1.6807571092926594, 2.362438397852783]
+
+    @test ndims(pred1) == 1
+
+    @test ndims(pred2.prediction) == 1
+    @test ndims(pred2.lower) == 1
+    @test ndims(pred2.upper) == 1
 
     pred3 = predict(mm, newX, interval=:prediction)
     @test pred1 == pred3.prediction ≈


### PR DESCRIPTION
This PR fixes the docstring of `predict(::LinearModel, x; interval, level)`, which claimed to return a matrix with 3 columns, whereas it is actually a named tuple with three fields (`prediction`, `lower`, `upper`).

It also fixes the types of the returned `lower` and `upper`. Previously, `prediction` was a vector (IMO, the correct shape), whereas `lower` and `upper` were `N x 1` matrices (IMO, the incorrect shape). Now, all three are vectors.