### PR TITLE
Do not mention pseudo-R² in manual

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -152,7 +152,8 @@ Many of the methods provided by this package have names similar to those in [R](
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
-- `r2`: R² of a linear model or pseudo-R² of a generalized linear model
+- `r2`: R² of a linear model
+- `adjr2`: adjusted R² of a linear model
 - `stderror`: standard errors of the coefficients
 - `vcov`: estimated variance-covariance matrix of the coefficient estimates
 - `predict` : obtain predicted values of the dependent variable from the fitted model


### PR DESCRIPTION
`r2` does not work for GLMs currently (even with two arguments) as they don't implement `nullloglikelihood`.
Also add a mention about `adjr2`.

If somebody has an idea regarding how `nullloglikelihood` could be implemented... Maybe all we need to do is define for each link what the prediction would be for all observations under the null model, and call `loglik_obs` on that like we do for `loglikelihood`?