### PR TITLE
Fix mention of canonical link for NegativeBinomial

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ functions are
             Binomial (LogitLink)
                Gamma (InverseLink)
      InverseGaussian (InverseSquareLink)
-    NegativeBinomial (LogLink)
+    NegativeBinomial (NegativeBinomialLink, often used with LogLink)
               Normal (IdentityLink)
              Poisson (LogLink)
 


### PR DESCRIPTION
In the text below we say that it is frequent to use the log link with negative binomial, so it makes sense to mention it here too.

Fixes https://github.com/JuliaStats/GLM.jl/issues/476.