### PR TITLE
Readability improvement

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -42,6 +42,49 @@ julia> round.(predict(ols), digits=5)
  1.83333
  4.33333
  6.83333
+
+julia> round.(confint(ols); digits=5)
+2×2 Matrix{Float64}:
+ -8.59038  7.25704
+ -1.16797  6.16797
+
+julia> round(r2(ols); digits=5)
+0.98684
+
+julia> round(adjr2(ols); digits=5)
+0.97368
+
+julia> round(deviance(ols); digits=5)
+0.16667
+
+julia> dof(ols)
+3
+
+julia> dof_residual(ols)
+1.0
+
+julia> round(aic(ols); digits=5)
+5.84252
+
+julia> round(aicc(ols); digits=5)
+-18.15748
+
+julia> round(bic(ols); digits=5)
+3.13835
+
+julia> round(dispersion(ols.model); digits=5)
+0.40825
+
+julia> round(loglikelihood(ols); digits=5)
+0.07874
+
+julia> round(nullloglikelihood(ols); digits=5)
+-6.41736
+
+julia> round.(vcov(ols); digits=5)
+2×2 Matrix{Float64}:
+  0.38889  -0.16667
+ -0.16667   0.08333
 ```
 
 ## Probit regression

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -8,7 +8,7 @@ end
 
 ## Linear regression
 ```jldoctest
-julia> using DataFrames, GLM
+julia> using DataFrames, GLM, StatsBase
 
 julia> data = DataFrame(X=[1,2,3], Y=[2,4,7])
 3×2 DataFrame

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -165,7 +165,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `modelmatrix`: return the design matrix
 - `nobs`: return the number of rows, or sum of the weights when prior weights are specified
 - `nulldeviance`: return the deviance of the linear model which includes the intercept only
-- `nullloglikelihood`: return the log-likelihood of the null model corresponding to the fitted linear model
+- `nullloglikelihood`: return the log-likelihood of the linear model which includes the intercept only
 - `predict` : obtain predicted values of the dependent variable from the fitted model
 - `r2`: R² of a linear model (an alias for `r²`)
 - `residuals`: get the vector of residuals from the fitted model

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -152,6 +152,7 @@ Many of the methods provided by this package have names similar to those in [R](
 the likelihood of the model, ``k`` is the number of consumed degrees of freedom
 - `coef`: extract the estimates of the coefficients in the model
 - `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)
+- `cooksdistance`: compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
 - `dof`: return the number of degrees of freedom consumed in the model, including
 when applicable the intercept and the distribution's dispersion parameter
@@ -173,8 +174,83 @@ when applicable the intercept and the distribution's dispersion parameter
 - `stderror`: standard errors of the coefficients
 - `vcov`: estimated variance-covariance matrix of the coefficient estimates
 
+
 Note that the canonical link for negative binomial regression is `NegativeBinomialLink`, but
 in practice one typically uses `LogLink`.
+
+```jldoctest methods
+julia> using GLM, DataFrames
+julia> data = DataFrame(X=[1,2,3], y=[2,4,7])
+julia> test_data = DataFrame(X=[4])
+julia> mdl = lm(@formula(y ~  X), data)
+julia> r2(mdl)
+0.9868421052631579
+
+julia> adjr2(mdl)
+0.9736842105263157
+
+julia> bic(mdl)
+3.1383527915438716
+
+julia> coef(mdl)
+2-element Vector{Float64}:
+ -0.6666666666666728
+  2.500000000000003
+
+julia> confint(mdl, level=0.90)
+2×2 Matrix{Float64}:
+ -4.60398   3.27065
+  0.677377  4.32262
+
+julia> deviance(mdl)
+0.16666666666666666
+
+julia> dof(mdl)
+3
+
+julia> dof_residual(mdl)
+1.0
+
+julia> aic(mdl)
+5.8425159255395425
+
+julia> aicc(mdl)
+-18.157484074460456
+
+julia> loglikelihood(mdl)
+0.07874203723022877
+
+julia> nullloglikelihood(mdl)
+-6.417357973199268
+```
+`predict` method returns predicted values of response variable from covariate values `newX`.
+If you ommit `newX` then it return fitted response values.
+
+```jldoctest methods
+julia> predict(mdl)
+3-element Vector{Float64}:
+ 1.8333333333333304
+ 4.333333333333333
+ 6.833333333333336
+
+julia> predict(mdl, test_data)
+1-element Vector{Union{Missing, Float64}}:
+ 9.33333333333334
+
+julia> stderror(mdl)
+2-element Vector{Float64}:
+ 0.6236095644623237
+ 0.2886751345948129
+```
+`cooksdistance` method computes [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
+
+```jldoctest methods
+julia> cooksdistance(mdl)
+3-element Vector{Float64}:
+ 2.500000000000079
+ 0.2499999999999991
+ 2.499999999999919
+```
 
 ## Separation of response object and predictor object
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -156,8 +156,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `cooksdistance`: compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
 - `dispersion`: return the estimated dispersion (or scale) parameter for a model's distribution
-- `dof`: return the number of degrees of freedom consumed in the model, including
-when applicable the intercept and the distribution's dispersion parameter
+- `dof`: return the number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `fitted`: return the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -158,7 +158,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `dispersion`: dispersion (or scale) parameter for a model's distribution
 - `dof`: number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
-- `fitted`: the fitted values of the model
+- `fitted`: fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
 - `loglikelihood`: log-likelihood of the model

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -153,7 +153,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `bic`: Bayesian Information Criterion
 - `coef`: estimates of the coefficients in the model
 - `confint`: confidence intervals for coefficients
-- `cooksdistance`: [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
+- `cooksdistance`: [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
 - `dispersion`: dispersion (or scale) parameter for a model's distribution
 - `dof`: the number of degrees of freedom consumed in the model

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -147,16 +147,31 @@ F-test: 2 models fitted on 50 observations
 ## Methods applied to fitted models
 
 Many of the methods provided by this package have names similar to those in [R](http://www.r-project.org).
+- `adjr2`:  adjusted R² for a linear model
+- `bic`: Bayesian Information Criterion, defined as ``-2 \\log L + k \\log n``, with ``L``
+the likelihood of the model, ``k`` is the number of consumed degrees of freedom
 - `coef`: extract the estimates of the coefficients in the model
+- `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
+- `dof`: return the number of degrees of freedom consumed in the model, including
+when applicable the intercept and the distribution's dispersion parameter
 - `dof_residual`: degrees of freedom for residuals, when meaningful
+- `fitted`: return the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
+- `aic`: Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood of the model, and `k` it the number of consumed degrees of freedom
+- `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
-- `r2`: R² of a linear model or pseudo-R² of a generalized linear model
+- `loglikelihood`: return the log-likelihood of the model
+- `modelmatrix`: return the design matrix
+- `nobs`: return the number of rows, or sum of the weights when prior weights are specified
+- `nulldeviance`: return the deviance of the linear model which includs the intercept only
+- `nullloglikelihood`: return the log-likelihood of the null model corresponding to the fitted linear model
+- `predict` : obtain predicted values of the dependent variable from the fitted model
+- `r2`: R² of a linear model
+- `residuals`: get the vector of residuals from the fitted model
+- `response`: return the model response (a.k.a the dependent variable)
 - `stderror`: standard errors of the coefficients
 - `vcov`: estimated variance-covariance matrix of the coefficient estimates
-- `predict` : obtain predicted values of the dependent variable from the fitted model
-- `residuals`: get the vector of residuals from the fitted model
 
 Note that the canonical link for negative binomial regression is `NegativeBinomialLink`, but
 in practice one typically uses `LogLink`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -164,8 +164,8 @@ Many of the methods provided by this package have names similar to those in [R](
 - `loglikelihood`: log-likelihood of the model
 - `modelmatrix`: design matrix
 - `nobs`: number of rows, or sum of the weights when prior weights are specified
-- `nulldeviance`: deviance of the linear model which includes the intercept only
-- `nullloglikelihood`: log-likelihood of the linear model which includes the intercept only
+- `nulldeviance`: deviance of the model with all predictors removed
+- `nullloglikelihood`: log-likelihood of the model with all predictors removed
 - `predict`: obtain predicted values of the dependent variable from the fitted model
 - `r2`: R² of a linear model (an alias for `r²`)
 - `residuals`: vector of residuals from the fitted model

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ functions are
             Binomial (LogitLink)
                Gamma (InverseLink)
      InverseGaussian (InverseSquareLink)
-    NegativeBinomial (LogLink)
+    NegativeBinomial (NegativeBinomialLink, often used with LogLink)
               Normal (IdentityLink)
              Poisson (LogLink)
 
@@ -156,6 +156,7 @@ the likelihood of the model, ``k`` is the number of consumed degrees of freedom
 - `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)
 - `cooksdistance`: compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
+- `dispersion`: return the estimated dispersion (or scale) parameter for a model's distribution
 - `dof`: return the number of degrees of freedom consumed in the model, including
 when applicable the intercept and the distribution's dispersion parameter
 - `dof_residual`: degrees of freedom for residuals, when meaningful
@@ -197,16 +198,16 @@ julia> stderror(mdl)
  0.6236095644623237
  0.2886751345948129
 
+julia> confint(mdl, level=0.90)
+2×2 Matrix{Float64}:
+ -4.60398   3.27065
+  0.677377  4.32262
+  
 julia> r2(mdl)
 0.9868421052631579
 
 julia> adjr2(mdl)
 0.9736842105263157
-
-julia> confint(mdl, level=0.90)
-2×2 Matrix{Float64}:
- -4.60398   3.27065
-  0.677377  4.32262
 
 julia> deviance(mdl)
 0.16666666666666666
@@ -226,14 +227,22 @@ julia> aicc(mdl)
 julia> bic(mdl)
 3.1383527915438716
 
+julia> dispersion(mdl.model)
+0.408248290463863
+
 julia> loglikelihood(mdl)
 0.07874203723022877
 
 julia> nullloglikelihood(mdl)
 -6.417357973199268
+
+julia> vcov(mdl)
+2×2 Matrix{Float64}:
+  0.388889  -0.166667
+ -0.166667   0.0833333
 ```
 `predict` method returns predicted values of response variable from covariate values `newX`.
-If you ommit `newX` then it return fitted response values.
+If you ommit `newX` then it return fitted response values. You will find more about [predict](https://juliastats.org/GLM.jl/stable/api/#StatsBase.predict) in the API docuemnt.
 
 ```jldoctest methods
 julia> predict(mdl)
@@ -241,6 +250,9 @@ julia> predict(mdl)
  1.8333333333333304
  4.333333333333333
  6.833333333333336
+
+julia> fitted(mdl) ≈ predict(mdl)
+true
 
 julia> predict(mdl, test_data)
 1-element Vector{Union{Missing, Float64}}:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -147,29 +147,29 @@ F-test: 2 models fitted on 50 observations
 ## Methods applied to fitted models
 
 Many of the methods provided by this package have names similar to those in [R](http://www.r-project.org).
-- `adjr2`:  adjusted R² for a linear model (an alias for `adjr²`)
+- `adjr2`: adjusted R² for a linear model (an alias for `adjr²`)
 - `aic`: Akaike's Information Criterion
 - `aicc`: corrected Akaike's Information Criterion for small sample sizes
 - `bic`: Bayesian Information Criterion
-- `coef`: extract the estimates of the coefficients in the model
-- `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)
-- `cooksdistance`: compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
+- `coef`: estimates of the coefficients in the model
+- `confint`: confidence intervals for coefficients
+- `cooksdistance`: [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
-- `dispersion`: return the estimated dispersion (or scale) parameter for a model's distribution
+- `dispersion`: estimated dispersion (or scale) parameter for a model's distribution
 - `dof`: return the number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `fitted`: return the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
-- `loglikelihood`: return the log-likelihood of the model
-- `modelmatrix`: return the design matrix
-- `nobs`: return the number of rows, or sum of the weights when prior weights are specified
-- `nulldeviance`: return the deviance of the linear model which includes the intercept only
-- `nullloglikelihood`: return the log-likelihood of the linear model which includes the intercept only
-- `predict` : obtain predicted values of the dependent variable from the fitted model
+- `loglikelihood`: log-likelihood of the model
+- `modelmatrix`: design matrix
+- `nobs`: number of rows, or sum of the weights when prior weights are specified
+- `nulldeviance`: deviance of the linear model which includes the intercept only
+- `nullloglikelihood`: log-likelihood of the linear model which includes the intercept only
+- `predict`: obtain predicted values of the dependent variable from the fitted model
 - `r2`: R² of a linear model (an alias for `r²`)
-- `residuals`: get the vector of residuals from the fitted model
-- `response`: return the model response (a.k.a the dependent variable)
+- `residuals`: vector of residuals from the fitted model
+- `response`: model response (a.k.a the dependent variable)
 - `stderror`: standard errors of the coefficients
 - `vcov`: estimated variance-covariance matrix of the coefficient estimates
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -178,7 +178,7 @@ Note that the canonical link for negative binomial regression is `NegativeBinomi
 in practice one typically uses `LogLink`.
 
 ```jldoctest methods
-julia> using GLM, DataFrames;
+julia> using GLM, DataFrames, StatsBase;
 
 julia> data = DataFrame(X=[1,2,3], y=[2,4,7]);
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -178,13 +178,11 @@ Note that the canonical link for negative binomial regression is `NegativeBinomi
 in practice one typically uses `LogLink`.
 
 ```jldoctest methods
-julia> using GLM, DataFrames, StatsBase;
+julia> using GLM, DataFrames, StatsBase
 
 julia> data = DataFrame(X=[1,2,3], y=[2,4,7]);
 
-julia> test_data = DataFrame(X=[4]);
-
-julia> mdl = lm(@formula(y ~  X), data);
+julia> mdl = lm(@formula(y ~ X), data);
 
 julia> round.(coef(mdl); digits=8)
 2-element Vector{Float64}:
@@ -197,15 +195,20 @@ julia> round(r2(mdl); digits=8)
 julia> round(aic(mdl); digits=8)
 5.84251593
 ```
-`predict` method returns predicted values of response variable from covariate values `newX`.
-If you ommit `newX` then it return fitted response values. You will find more about [predict](https://juliastats.org/GLM.jl/stable/api/#StatsBase.predict) in the API docuemnt.
+
+The [`predict`](@ref) method returns predicted values of response variable from covariate values in an input `newX`.
+If `newX` is omitted then the fitted response values from the model are returned.
 
 ```jldoctest methods
+julia> test_data = DataFrame(X=[4]);
+
 julia> round.(predict(mdl, test_data); digits=8)
 1-element Vector{Float64}:
  9.33333333
 ```
-`cooksdistance` method computes [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
+
+The [`cooksdistance`](@ref) method computes [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation used to fit a linear model, giving an estimate of the influence of each data point.
+Note that it's currently only implemented for linear models without weights.
 
 ```jldoctest methods
 julia> round.(cooksdistance(mdl); digits=8)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -150,8 +150,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `adjr2`:  adjusted R² for a linear model (an alias for `adjr²`)
 - `aic`: Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood of the model, and `k` it the number of consumed degrees of freedom
 - `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
-- `bic`: Bayesian Information Criterion, defined as ``-2 \\log L + k \\log n``, with ``L``
-the likelihood of the model, ``k`` is the number of consumed degrees of freedom
+- `bic`: Bayesian Information Criterion
 - `coef`: extract the estimates of the coefficients in the model
 - `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)
 - `cooksdistance`: compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -147,7 +147,9 @@ F-test: 2 models fitted on 50 observations
 ## Methods applied to fitted models
 
 Many of the methods provided by this package have names similar to those in [R](http://www.r-project.org).
-- `adjr2`:  adjusted R² for a linear model
+- `adjr2`:  adjusted R² for a linear model (an alias for `adjr²`)
+- `aic`: Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood of the model, and `k` it the number of consumed degrees of freedom
+- `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
 - `bic`: Bayesian Information Criterion, defined as ``-2 \\log L + k \\log n``, with ``L``
 the likelihood of the model, ``k`` is the number of consumed degrees of freedom
 - `coef`: extract the estimates of the coefficients in the model
@@ -159,8 +161,6 @@ when applicable the intercept and the distribution's dispersion parameter
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `fitted`: return the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
-- `aic`: Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood of the model, and `k` it the number of consumed degrees of freedom
-- `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
 - `loglikelihood`: return the log-likelihood of the model
 - `modelmatrix`: return the design matrix
@@ -168,7 +168,7 @@ when applicable the intercept and the distribution's dispersion parameter
 - `nulldeviance`: return the deviance of the linear model which includs the intercept only
 - `nullloglikelihood`: return the log-likelihood of the null model corresponding to the fitted linear model
 - `predict` : obtain predicted values of the dependent variable from the fitted model
-- `r2`: R² of a linear model
+- `r2`: R² of a linear model (an alias for `r²`)
 - `residuals`: get the vector of residuals from the fitted model
 - `response`: return the model response (a.k.a the dependent variable)
 - `stderror`: standard errors of the coefficients
@@ -179,23 +179,29 @@ Note that the canonical link for negative binomial regression is `NegativeBinomi
 in practice one typically uses `LogLink`.
 
 ```jldoctest methods
-julia> using GLM, DataFrames
-julia> data = DataFrame(X=[1,2,3], y=[2,4,7])
-julia> test_data = DataFrame(X=[4])
-julia> mdl = lm(@formula(y ~  X), data)
-julia> r2(mdl)
-0.9868421052631579
+julia> using GLM, DataFrames;
 
-julia> adjr2(mdl)
-0.9736842105263157
+julia> data = DataFrame(X=[1,2,3], y=[2,4,7]);
 
-julia> bic(mdl)
-3.1383527915438716
+julia> test_data = DataFrame(X=[4]);
+
+julia> mdl = lm(@formula(y ~  X), data);
 
 julia> coef(mdl)
 2-element Vector{Float64}:
  -0.6666666666666728
   2.500000000000003
+  
+julia> stderror(mdl)
+2-element Vector{Float64}:
+ 0.6236095644623237
+ 0.2886751345948129
+
+julia> r2(mdl)
+0.9868421052631579
+
+julia> adjr2(mdl)
+0.9736842105263157
 
 julia> confint(mdl, level=0.90)
 2×2 Matrix{Float64}:
@@ -217,6 +223,9 @@ julia> aic(mdl)
 julia> aicc(mdl)
 -18.157484074460456
 
+julia> bic(mdl)
+3.1383527915438716
+
 julia> loglikelihood(mdl)
 0.07874203723022877
 
@@ -236,11 +245,6 @@ julia> predict(mdl)
 julia> predict(mdl, test_data)
 1-element Vector{Union{Missing, Float64}}:
  9.33333333333334
-
-julia> stderror(mdl)
-2-element Vector{Float64}:
- 0.6236095644623237
- 0.2886751345948129
 ```
 `cooksdistance` method computes [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -155,10 +155,10 @@ Many of the methods provided by this package have names similar to those in [R](
 - `confint`: confidence intervals for coefficients
 - `cooksdistance`: [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
-- `dispersion`: estimated dispersion (or scale) parameter for a model's distribution
-- `dof`: return the number of degrees of freedom consumed in the model
+- `dispersion`: dispersion (or scale) parameter for a model's distribution
+- `dof`: the number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
-- `fitted`: return the fitted values of the model
+- `fitted`: the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
 - `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
 - `loglikelihood`: log-likelihood of the model
@@ -171,7 +171,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `residuals`: vector of residuals from the fitted model
 - `response`: model response (a.k.a the dependent variable)
 - `stderror`: standard errors of the coefficients
-- `vcov`: estimated variance-covariance matrix of the coefficient estimates
+- `vcov`: variance-covariance matrix of the coefficient estimates
 
 
 Note that the canonical link for negative binomial regression is `NegativeBinomialLink`, but
@@ -190,68 +190,17 @@ julia> round.(coef(mdl); digits=8)
 2-element Vector{Float64}:
  -0.66666667
   2.5
-  
-julia> round.(stderror(mdl); digits=8)
-2-element Vector{Float64}:
- 0.62360956
- 0.28867513
 
-julia> round.(confint(mdl); digits=8)
-2×2 Matrix{Float64}:
- -8.59038  7.25704
- -1.16797  6.16797
-  
 julia> round(r2(mdl); digits=8)
 0.98684211
 
-julia> round(adjr2(mdl); digits=8)
-0.97368421
-
-julia> round(deviance(mdl); digits=8)
-0.16666667
-
-julia> dof(mdl)
-3
-
-julia> dof_residual(mdl)
-1.0
-
 julia> round(aic(mdl); digits=8)
 5.84251593
-
-julia> round(aicc(mdl); digits=8)
--18.15748407
-
-julia> round(bic(mdl); digits=8)
-3.13835279
-
-julia> round(dispersion(mdl.model); digits=8)
-0.40824829
-
-julia> round(loglikelihood(mdl); digits=8)
-0.07874204
-
-julia> round(nullloglikelihood(mdl); digits=8)
--6.41735797
-
-julia> round.(vcov(mdl); digits=8)
-2×2 Matrix{Float64}:
-  0.388889  -0.166667
- -0.166667   0.0833333
 ```
 `predict` method returns predicted values of response variable from covariate values `newX`.
 If you ommit `newX` then it return fitted response values. You will find more about [predict](https://juliastats.org/GLM.jl/stable/api/#StatsBase.predict) in the API docuemnt.
 
 ```jldoctest methods
-julia> round.(predict(mdl); digits=8)
-3-element Vector{Float64}:
- 1.83333333
- 4.33333333
- 6.83333333
-
-julia> fitted(mdl) ≈ predict(mdl)
-true
-
 julia> round.(predict(mdl, test_data); digits=8)
 1-element Vector{Float64}:
  9.33333333

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -166,7 +166,7 @@ when applicable the intercept and the distribution's dispersion parameter
 - `loglikelihood`: return the log-likelihood of the model
 - `modelmatrix`: return the design matrix
 - `nobs`: return the number of rows, or sum of the weights when prior weights are specified
-- `nulldeviance`: return the deviance of the linear model which includs the intercept only
+- `nulldeviance`: return the deviance of the linear model which includes the intercept only
 - `nullloglikelihood`: return the log-likelihood of the null model corresponding to the fitted linear model
 - `predict` : obtain predicted values of the dependent variable from the fitted model
 - `r2`: R² of a linear model (an alias for `r²`)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -149,7 +149,7 @@ F-test: 2 models fitted on 50 observations
 Many of the methods provided by this package have names similar to those in [R](http://www.r-project.org).
 - `adjr2`:  adjusted R² for a linear model (an alias for `adjr²`)
 - `aic`: Akaike's Information Criterion
-- `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
+- `aicc`: corrected Akaike's Information Criterion for small sample sizes
 - `bic`: Bayesian Information Criterion
 - `coef`: extract the estimates of the coefficients in the model
 - `confint`: compute confidence intervals for coefficients, with confidence level `level` (by default 95%)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -166,7 +166,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `nobs`: number of rows, or sum of the weights when prior weights are specified
 - `nulldeviance`: deviance of the model with all predictors removed
 - `nullloglikelihood`: log-likelihood of the model with all predictors removed
-- `predict`: obtain predicted values of the dependent variable from the fitted model
+- `predict`: predicted values of the dependent variable from the fitted model
 - `r2`: R² of a linear model (an alias for `r²`)
 - `residuals`: vector of residuals from the fitted model
 - `response`: model response (a.k.a the dependent variable)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -148,7 +148,7 @@ F-test: 2 models fitted on 50 observations
 
 Many of the methods provided by this package have names similar to those in [R](http://www.r-project.org).
 - `adjr2`:  adjusted R² for a linear model (an alias for `adjr²`)
-- `aic`: Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood of the model, and `k` it the number of consumed degrees of freedom
+- `aic`: Akaike's Information Criterion
 - `aicc`: corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989)
 - `bic`: Bayesian Information Criterion
 - `coef`: extract the estimates of the coefficients in the model

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -188,29 +188,29 @@ julia> test_data = DataFrame(X=[4]);
 
 julia> mdl = lm(@formula(y ~  X), data);
 
-julia> coef(mdl)
+julia> round.(coef(mdl); digits=8)
 2-element Vector{Float64}:
- -0.6666666666666728
-  2.500000000000003
+ -0.66666667
+  2.5
   
-julia> stderror(mdl)
+julia> round.(stderror(mdl); digits=8)
 2-element Vector{Float64}:
- 0.6236095644623237
- 0.2886751345948129
+ 0.62360956
+ 0.28867513
 
-julia> confint(mdl, level=0.90)
+julia> round.(confint(mdl); digits=8)
 2×2 Matrix{Float64}:
- -4.60398   3.27065
-  0.677377  4.32262
+ -8.59038  7.25704
+ -1.16797  6.16797
   
-julia> r2(mdl)
-0.9868421052631579
+julia> round(r2(mdl); digits=8)
+0.98684211
 
-julia> adjr2(mdl)
-0.9736842105263157
+julia> round(adjr2(mdl); digits=8)
+0.97368421
 
-julia> deviance(mdl)
-0.16666666666666666
+julia> round(deviance(mdl); digits=8)
+0.16666667
 
 julia> dof(mdl)
 3
@@ -218,25 +218,25 @@ julia> dof(mdl)
 julia> dof_residual(mdl)
 1.0
 
-julia> aic(mdl)
-5.8425159255395425
+julia> round(aic(mdl); digits=8)
+5.84251593
 
-julia> aicc(mdl)
--18.157484074460456
+julia> round(aicc(mdl); digits=8)
+-18.15748407
 
-julia> bic(mdl)
-3.1383527915438716
+julia> round(bic(mdl); digits=8)
+3.13835279
 
-julia> dispersion(mdl.model)
-0.408248290463863
+julia> round(dispersion(mdl.model); digits=8)
+0.40824829
 
-julia> loglikelihood(mdl)
-0.07874203723022877
+julia> round(loglikelihood(mdl); digits=8)
+0.07874204
 
-julia> nullloglikelihood(mdl)
--6.417357973199268
+julia> round(nullloglikelihood(mdl); digits=8)
+-6.41735797
 
-julia> vcov(mdl)
+julia> round.(vcov(mdl); digits=8)
 2×2 Matrix{Float64}:
   0.388889  -0.166667
  -0.166667   0.0833333
@@ -245,27 +245,27 @@ julia> vcov(mdl)
 If you ommit `newX` then it return fitted response values. You will find more about [predict](https://juliastats.org/GLM.jl/stable/api/#StatsBase.predict) in the API docuemnt.
 
 ```jldoctest methods
-julia> predict(mdl)
+julia> round.(predict(mdl); digits=8)
 3-element Vector{Float64}:
- 1.8333333333333304
- 4.333333333333333
- 6.833333333333336
+ 1.83333333
+ 4.33333333
+ 6.83333333
 
 julia> fitted(mdl) ≈ predict(mdl)
 true
 
-julia> predict(mdl, test_data)
-1-element Vector{Union{Missing, Float64}}:
- 9.33333333333334
+julia> round.(predict(mdl, test_data); digits=8)
+1-element Vector{Float64}:
+ 9.33333333
 ```
 `cooksdistance` method computes [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation in linear model `obj`, giving an estimate of the influence of each data point. Currently only implemented for linear models without weights.
 
 ```jldoctest methods
-julia> cooksdistance(mdl)
+julia> round.(cooksdistance(mdl); digits=8)
 3-element Vector{Float64}:
- 2.500000000000079
- 0.2499999999999991
- 2.499999999999919
+ 2.5
+ 0.25
+ 2.5
 ```
 
 ## Separation of response object and predictor object

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -156,7 +156,7 @@ Many of the methods provided by this package have names similar to those in [R](
 - `cooksdistance`: [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance) for each observation
 - `deviance`: measure of the model fit, weighted residual sum of squares for lm's
 - `dispersion`: dispersion (or scale) parameter for a model's distribution
-- `dof`: the number of degrees of freedom consumed in the model
+- `dof`: number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `fitted`: the fitted values of the model
 - `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -20,7 +20,7 @@ module GLM
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fitted, fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²,
-           cooksdistance, hasintercept
+           cooksdistance, hasintercept, dispersion
 
     export
         # types

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,14 +12,15 @@ module GLM
     import Statistics: cor
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
                       loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-                      fitted, fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue
+                      fitted, fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue,
+                      aic, aicc, bic
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv, digamma, trigamma
     import StatsModels: hasintercept
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fitted, fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²,
-           cooksdistance, hasintercept
+           cooksdistance, hasintercept, aic, aicc, bic
 
     export
         # types

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -20,7 +20,7 @@ module GLM
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fitted, fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²,
-           cooksdistance, hasintercept, aic, aicc, bic
+           cooksdistance, hasintercept, aic, aicc, bic, dispersion
 
     export
         # types

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -20,7 +20,7 @@ module GLM
     export coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
            loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
            fitted, fit, fit!, model_response, response, modelmatrix, r2, r², adjr2, adjr²,
-           cooksdistance, hasintercept, aic, aicc, bic, dispersion
+           cooksdistance, hasintercept
 
     export
         # types

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,8 +12,7 @@ module GLM
     import Statistics: cor
     import StatsBase: coef, coeftable, confint, deviance, nulldeviance, dof, dof_residual,
                       loglikelihood, nullloglikelihood, nobs, stderror, vcov, residuals, predict,
-                      fitted, fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue,
-                      aic, aicc, bic
+                      fitted, fit, model_response, response, modelmatrix, r2, r², adjr2, adjr², PValue
     import StatsFuns: xlogy
     import SpecialFunctions: erfc, erfcinv, digamma, trigamma
     import StatsModels: hasintercept


### PR DESCRIPTION
In this PR, to improve the readability of the GLM document, we have:

- exported a few methods like `aic`, `aicc`, `bic`, `dispersion` so that, users can access these methods from `GLM` directly
- added a short description of the methods that can be applied to a fitted model
- added some examples to show how to use these methods


