### PR TITLE
add compat for statsmodels 0.7

### DIFF
--- a/.github/workflows/CI-future.yml
+++ b/.github/workflows/CI-future.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - master
+      - v1
   push:
     branches:
       - master
+      - v1
     tags: '*'
 jobs:
   test:

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - master
+      - v1
   push:
     branches:
       - master
+      - v1
     tags: '*'
 jobs:
   test:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLM"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ SpecialFunctions = "0.6, 0.7, 0.8, 0.9, 0.10, 1, 2.0"
 StatsAPI = "1.4"
 StatsBase = "0.33.5"
 StatsFuns = "0.6, 0.7, 0.8, 0.9, 1.0"
-StatsModels = "0.6.23"
+StatsModels = "0.6.23, 0.7"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
We will tag 0.7 very soon (~~probably today~~ ahahaha good one...) with changes to `FunctionTerm` that are breaking but do not directly affect anything that GLM itself uses.  This PR should not be merged until 0.7 is tagged and CI can be run to ensure that nothing breaks in GLM, so I'll start this in draft mode and flip it out when it's time to check CI.

Update: 0.7 is now released.  I've added bumped the patch version here and also fixed a bug where we were defining our own `formula` function instead of creating a method for `StatsModels.formula`.

Update to teh update: based on #500, I re-based this on a commit before #339 was merged, targeting a "backport" branch called `v1`.