### PR TITLE
Set tolerance to zero in pivoted Cholesky

### DIFF
--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -104,7 +104,7 @@ end
 function DensePredChol(X::AbstractMatrix, pivot::Bool)
     F = Hermitian(float(X'X))
     T = eltype(F)
-    F = pivot ? pivoted_cholesky!(F, tol = -one(T), check = false) : cholesky!(F)
+    F = pivot ? pivoted_cholesky!(F, tol = 0, check = false) : cholesky!(F)
     DensePredChol(Matrix{T}(X),
         zeros(T, size(X, 2)),
         zeros(T, size(X, 2)),


### PR DESCRIPTION
Right now, we rely on a default that is more likely to calculate a smaller rank. When setting it to zero, the rank will only be reduced when the matrix is exactly singular or slightly indefinite which I think is the beneficial behavior. Otherwise, we'll drop predictors too frequently, see https://github.com/JuliaStats/GLM.jl/pull/507#discussion_r1145045405