### PR TITLE
Set minimum Julia version to 1.6 (#514)

### DIFF
--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.0', '1']
+        version: ['1.6', '1']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         arch: ['x64']
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ StatsAPI = "1.4"
 StatsBase = "0.33.5, 0.34"
 StatsFuns = "0.6, 0.7, 0.8, 0.9, 1.0"
 StatsModels = "0.6.23, 0.7"
-julia = "1"
+julia = "1.6"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,21 +190,20 @@ end
 
     # Saturated and rank-deficient model
     df = DataFrame(x1=["a", "b", "c"], x2=["a", "b", "c"], y=[1, 2, 3])
-    model = lm(@formula(y ~ x1 + x2), df)
-    ct = coeftable(model)
-    @test dof_residual(model) == 0
-    @test dof(model) == 4
-    @test isinf(GLM.dispersion(model.model))
-    @test coef(model) ≈ [1, 1, 2, 0, 0]
-    @test isequal(hcat(ct.cols[2:end]...),
-                  [Inf 0.0 1.0 -Inf Inf
-                   Inf 0.0 1.0 -Inf Inf
-                   Inf 0.0 1.0 -Inf Inf
-                   NaN NaN NaN  NaN NaN
-                   NaN NaN NaN  NaN NaN])
-
-    # TODO: add tests similar to the one above once this model can be fitted
-    @test_broken glm(@formula(y ~ x1 + x2), df, Normal(), IdentityLink())
+    for model in (lm(@formula(y ~ x1 + x2), df),
+                  glm(@formula(y ~ x1 + x2), df, Normal(), IdentityLink()))
+        ct = coeftable(model)
+        @test dof_residual(model) == 0
+        @test dof(model) == 4
+        @test isinf(GLM.dispersion(model.model))
+        @test coef(model) ≈ [1, 1, 2, 0, 0]
+        @test isequal(hcat(ct.cols[2:end]...),
+                      [Inf 0.0 1.0 -Inf Inf
+                       Inf 0.0 1.0 -Inf Inf
+                       Inf 0.0 1.0 -Inf Inf
+                       NaN NaN NaN  NaN NaN
+                       NaN NaN NaN  NaN NaN])
+    end
 end
 
 @testset "Linear model with no intercept" begin


### PR DESCRIPTION
* Set minimum Julia version to 1.6

Currently the minimum version is 1.0, which is old and unsupported and
makes development and addition of new features more difficult.

* Fix nightly CI

In Julia 1.10, at-test_broken will error if the expression doesn't
evaluate to a boolean value, making it consistent with at-test. We
actually can fit the model here; the test passes with prior Julia
versions only because the expression doesn't evaluate to a boolean.

(cherry picked from commit 57669ef89de3588ffdbf757d82fd28d5c71f5177)