### PR TITLE
Remove installbeta! and make linear model fit insensitive to beta0 state

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -64,7 +64,6 @@ fit
 StatsBase.deviance
 GLM.dispersion
 GLM.ftest
-GLM.installbeta!
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -19,3 +19,6 @@ function Base.getproperty(mm::LinPredModel, f::Symbol)
         return getfield(mm, f)
     end
 end
+
+@deprecate installbeta!(p) (p.beta0 .= p.delbeta) false
+@deprecate installbeta!(p, f) (p.beta0 .+= p.delbeta .* f) false

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -377,7 +377,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
         delbeta!(p, wrkresp(r), r.wrkwt)
         linpred!(lp, p)
         updateμ!(r, lp)
-        installbeta!(p)
+        p.beta0 .= p.delbeta
     else
         # otherwise copy starting values for β
         copy!(p.beta0, start)
@@ -415,7 +415,7 @@ function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real
                 isa(e, DomainError) ? (dev = Inf) : rethrow(e)
             end
         end
-        installbeta!(p, f)
+        p.beta0 .+= p.delbeta .* f
 
         # Test for convergence
         verbose && println("Iteration: $i, deviance: $dev, diff.dev.:$(devold - dev)")

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -18,21 +18,6 @@ Return the linear predictor `p.X * (p.beta0 .+ f * p.delbeta)`
 linpred(p::LinPred, f::Real=1.) = linpred!(Vector{eltype(p.X)}(undef, size(p.X, 1)), p, f)
 
 """
-    installbeta!(p::LinPred, f::Real=1.0)
-
-Install `pbeta0 .+= f * p.delbeta` and zero out `p.delbeta`.  Return the updated `p.beta0`.
-"""
-function installbeta!(p::LinPred, f::Real=1.)
-    beta0 = p.beta0
-    delbeta = p.delbeta
-    @inbounds for i = eachindex(beta0,delbeta)
-        beta0[i] += delbeta[i]*f
-        delbeta[i] = 0
-    end
-    beta0
-end
-
-"""
     DensePredQR
 
 A `LinPred` type with a dense QR decomposition of `X`
@@ -207,7 +192,7 @@ function delbeta!(p::DensePredChol{T,<:CholeskyPivoted}, r::Vector{T}) where T<:
     else
         permute!(delbeta, ch.p)
         for k=(rnk+1):length(delbeta)
-            delbeta[k] = -zero(T)
+            delbeta[k] = zero(T)
         end
         LAPACK.potrs!(ch.uplo, view(ch.factors, 1:rnk, 1:rnk), view(delbeta, 1:rnk))
         invpermute!(delbeta, ch.p)

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -95,10 +95,10 @@ LinearAlgebra.cholesky(x::LinearModel) = cholesky(x.pp)
 function StatsBase.fit!(obj::LinearModel)
     if isempty(obj.rr.wts)
         delbeta!(obj.pp, obj.rr.y)
-    else 
+    else
         delbeta!(obj.pp, obj.rr.y, obj.rr.wts)
     end
-    installbeta!(obj.pp)     
+    obj.pp.beta0 .= obj.pp.delbeta
     updateμ!(obj.rr, linpred(obj.pp, zero(eltype(obj.rr.y))))
     return obj
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,19 @@ linreg(x::AbstractVecOrMat, y::AbstractVector) = qr!(simplemm(x)) \ y
     # Deprecated methods
     @test lm1.model === lm1
     @test lm1.mf.f == formula(lm1)
+
+    @testset "low level constructors" begin
+        X = [ones(10) randn(10)]
+        y = X*ones(2) + randn(10)*0.1
+        r = GLM.LmResp(y)
+        pch = GLM.DensePredChol(X, false)
+        pqr = GLM.DensePredQR(X)
+        β̂ = X\y
+        @test coef(fit!(LinearModel(r, pch, nothing))) ≈ β̂
+        @test coef(fit!(LinearModel(r, pqr, nothing))) ≈ β̂
+        # Test last one once more to ensure that no state in pqr affects the result
+        @test coef(fit!(LinearModel(r, pqr, nothing))) ≈ β̂
+    end
 end
 
 @testset "Cook's Distance in Linear Model with $dmethod" for dmethod in (:cholesky, :qr)


### PR DESCRIPTION
When looking at https://github.com/JuliaStats/GLM.jl/issues/534 I noticed that `fit!(::LinearModel)` depended on the state of `beta0` stored in the linear predictor. The reason was that the solution stored in `delbeta` was transferred to `beta0` by the `installbeta!` method which updated the current value. This is important for GLMs but not LMs. Furthermore, the operations are so simple to do with broadcasting that I think we should rather just do that. (I think `installbeta!` might predate broadcasting in Julia.)