### PR TITLE
set version to 2.0.0-DEV

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLM"
 uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.8.1"
+version = "2.0.0-DEV"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
There are changes currently on `master` that we have determined are Technically Breaking. Setting the version to 2.0.0-DEV indicates the next version that will be released from master and that we're not yet in the state we want for that release.