### PR TITLE
[v1] Allow documentation building on push

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v1'
     tags: '*'
   pull_request:
 jobs:


### PR DESCRIPTION
I think this is why there the hosted documentation doesn't have 1.8. Once a documentation build with this has gone through, https://github.com/JuliaStats/GLM.jl/issues/541 will be resolved.