### PR TITLE
Let future test on beta instead of nightly

### DIFF
--- a/.github/workflows/CI-future.yml
+++ b/.github/workflows/CI-future.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['nightly']
+        version: ['beta']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         arch: ['x64']
     steps:


### PR DESCRIPTION
Early in the cycle, the failures on nightly are not that useful to us. We only really need to pay attention once Julia enters the beta stage.