### PR TITLE
Change dof_residual definition to not depend on dispersion parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-CSV = "0.7, 0.8"
+CSV = "0.7, 0.8, 0.9, 0.10"
 CategoricalArrays = "0.8, 0.9, 0.10"
 DataFrames = "0.22, 1"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -351,10 +351,7 @@ function nullloglikelihood(m::GeneralizedLinearModel)
     return ll
 end
 
-function dof(x::GeneralizedLinearModel)
-    modelrank = linpred_rank(x.pp)
-    dispersion_parameter(x.rr.d) ? modelrank + 1 : modelrank
-end
+dof(obj::GeneralizedLinearModel) = linpred_rank(obj) + dispersion_parameter(obj.rr.d)
 
 function _fit!(m::AbstractGLM, verbose::Bool, maxiter::Integer, minstepfac::Real,
                atol::Real, rtol::Real, start)

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -387,10 +387,11 @@ coef(obj::LinPredModel) = coef(obj.pp)
 coefnames(x::LinPredModel) =
     x.formula === nothing ? ["x$i" for i in 1:length(coef(x))] : coefnames(formula(x).rhs)
 
-dof_residual(obj::LinPredModel) = nobs(obj) - dof(obj) + 1
+dof_residual(obj::LinPredModel) = nobs(obj) - linpred_rank(obj)
 
 hasintercept(m::LinPredModel) = any(i -> all(==(1), view(m.pp.X , :, i)), 1:size(m.pp.X, 2))
 
+linpred_rank(x::LinPredModel) = linpred_rank(x.pp)
 linpred_rank(x::LinPred) = length(x.beta0)
 linpred_rank(x::DensePredChol{<:Any, <:CholeskyPivoted}) = rank(x.chol)
 linpred_rank(x::DensePredChol{<:Any, <:Cholesky}) = rank(x.chol.U)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1919,7 +1919,7 @@ end
         @test deviance(mdl) ≈ 135.68506068159
         @test loglikelihood(mdl) ≈ -67.8425303407948
         @test dof(mdl) == 3
-        @test dof_residual(mdl) == 98
+        @test dof_residual(mdl) == 97
         @test aic(mdl) ≈ 141.68506068159
         @test GLM.dispersion(mdl, true) ≈ 1
         @test predict(mdl)[1:3] ≈ [0.4241893070433117, 0.3754516361306202, 0.6327877688720133] atol = 1.0E-6


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/GLM.jl/issues/509

There was actually already a test of a model affected by this but the reference value was wrong. I checked the value in R. 

@nalimilan how do you feel about `dof` after all these years? After preparing this, I think we might be better of from deprecating `dof` (which would have to happen in `StatsAPI`). I tend to think that it brings more confusion than convenience.