### PR TITLE
Test with the pre target instead of nightly

### DIFF
--- a/.github/workflows/CI-future.yml
+++ b/.github/workflows/CI-future.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['nightly']
+        version: ['pre']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         arch: ['x64']
     steps:


### PR DESCRIPTION
There are too many irrelevant failures on nightly.