### PR TITLE
Remove all branches in runtests.jl associated with unsupported versions of Julia

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1325,15 +1325,9 @@ end
     @test ft1.dof ≈ dof(mod) - dof(nullmod)
     @test ft1.fstat ≈ ft1base.fstat[2]
     @test ft1.pval ≈ ft1base.pval[2]
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft1) == """
-            F-test against the null model:
-            F-statistic: 241.62 on 12 observations and 1 degrees of freedom, p-value: <1e-07"""
-    else
-        @test sprint(show, ft1) == """
-            F-test against the null model:
-            F-statistic: 241.62 on 12 observations and 1 degrees of freedom, p-value: <1e-7"""
-    end
+    @test sprint(show, ft1) == """
+        F-test against the null model:
+        F-statistic: 241.62 on 12 observations and 1 degrees of freedom, p-value: <1e-07"""
 
     ft2 = ftest(othermod)
     ft2base = ftest(nullmod, othermod)
@@ -1351,15 +1345,9 @@ end
     @test ft3.dof ≈ dof(bothmod) - dof(nullmod)
     @test ft3.fstat ≈ ft3base.fstat[2]
     @test ft3.pval ≈ ft3base.pval[2]
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft3) == """
-            F-test against the null model:
-            F-statistic: 81.97 on 12 observations and 3 degrees of freedom, p-value: <1e-05"""
-    else
-        @test sprint(show, ft3) == """
-            F-test against the null model:
-            F-statistic: 81.97 on 12 observations and 3 degrees of freedom, p-value: <1e-5"""
-    end
+    @test sprint(show, ft3) == """
+        F-test against the null model:
+        F-statistic: 81.97 on 12 observations and 3 degrees of freedom, p-value: <1e-05"""
 
     @test_throws ArgumentError ftest(nointerceptmod)
 end
@@ -1385,101 +1373,55 @@ end
     ft1a = ftest(mod, nullmod)
     @test isnan(ft1a.pval[1])
     @test ft1a.pval[2] ≈ 2.481215056713184e-8
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft1a) == """
-            F-test: 2 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    3        0.1283          0.9603                           
-            [2]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234  <1e-07
-            ─────────────────────────────────────────────────────────────────"""
-    else
-        @test sprint(show, ft1a) == """
-            F-test: 2 models fitted on 12 observations
-            ────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*  p(>F)
-            ────────────────────────────────────────────────────────────────
-            [1]    3        0.1283          0.9603                          
-            [2]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234  <1e-7
-            ────────────────────────────────────────────────────────────────"""
-    end
+    @test sprint(show, ft1a) == """
+        F-test: 2 models fitted on 12 observations
+        ─────────────────────────────────────────────────────────────────
+             DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*   p(>F)
+        ─────────────────────────────────────────────────────────────────
+        [1]    3        0.1283          0.9603                           
+        [2]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234  <1e-07
+        ─────────────────────────────────────────────────────────────────"""
 
     ft1b = ftest(nullmod, mod)
     @test isnan(ft1b.pval[1])
     @test ft1b.pval[2] ≈ 2.481215056713184e-8
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft1b) == """
-            F-test: 2 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    2        3.2292           0.0000                          
-            [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234  <1e-07
-            ─────────────────────────────────────────────────────────────────"""
-    else
-        @test sprint(show, ft1b) == """
-            F-test: 2 models fitted on 12 observations
-            ────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*  p(>F)
-            ────────────────────────────────────────────────────────────────
-            [1]    2        3.2292           0.0000                         
-            [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234  <1e-7
-            ────────────────────────────────────────────────────────────────"""
-    end
+    @test sprint(show, ft1b) == """
+        F-test: 2 models fitted on 12 observations
+        ─────────────────────────────────────────────────────────────────
+             DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*   p(>F)
+        ─────────────────────────────────────────────────────────────────
+        [1]    2        3.2292           0.0000                          
+        [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234  <1e-07
+        ─────────────────────────────────────────────────────────────────"""
 
     bigmod = lm(@formula(Result~Treatment+Other), d)
     ft2a = ftest(nullmod, mod, bigmod)
     @test isnan(ft2a.pval[1])
     @test ft2a.pval[2] ≈ 2.481215056713184e-8
     @test ft2a.pval[3] ≈ 0.3949973540194818
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft2a) == """
-            F-test: 3 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    2        3.2292           0.0000                          
-            [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234  <1e-07
-            [3]    5     2  0.1017  -0.0266  0.9685  0.0082    1.0456  0.3950
-            ─────────────────────────────────────────────────────────────────"""
-    else
-        @test sprint(show, ft2a) == """
-            F-test: 3 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    2        3.2292           0.0000                          
-            [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234   <1e-7
-            [3]    5     2  0.1017  -0.0266  0.9685  0.0082    1.0456  0.3950
-            ─────────────────────────────────────────────────────────────────"""
-    end
+    @test sprint(show, ft2a) == """
+        F-test: 3 models fitted on 12 observations
+        ─────────────────────────────────────────────────────────────────
+             DOF  ΔDOF     SSR     ΔSSR      R²     ΔR²        F*   p(>F)
+        ─────────────────────────────────────────────────────────────────
+        [1]    2        3.2292           0.0000                          
+        [2]    3     1  0.1283  -3.1008  0.9603  0.9603  241.6234  <1e-07
+        [3]    5     2  0.1017  -0.0266  0.9685  0.0082    1.0456  0.3950
+        ─────────────────────────────────────────────────────────────────"""
 
     ft2b = ftest(bigmod, mod, nullmod)
     @test isnan(ft2b.pval[1])
     @test ft2b.pval[2] ≈ 0.3949973540194818
     @test ft2b.pval[3] ≈ 2.481215056713184e-8
-    if VERSION >= v"1.6.0"
-        @test sprint(show, ft2b) == """
-            F-test: 3 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    5        0.1017          0.9685                           
-            [2]    3    -2  0.1283  0.0266  0.9603  -0.0082    1.0456  0.3950
-            [3]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234  <1e-07
-            ─────────────────────────────────────────────────────────────────"""
-    else
-        @test sprint(show, ft2b) == """
-            F-test: 3 models fitted on 12 observations
-            ─────────────────────────────────────────────────────────────────
-                 DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*   p(>F)
-            ─────────────────────────────────────────────────────────────────
-            [1]    5        0.1017          0.9685                           
-            [2]    3    -2  0.1283  0.0266  0.9603  -0.0082    1.0456  0.3950
-            [3]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234   <1e-7
-            ─────────────────────────────────────────────────────────────────"""
-    end
+    @test sprint(show, ft2b) == """
+        F-test: 3 models fitted on 12 observations
+        ─────────────────────────────────────────────────────────────────
+             DOF  ΔDOF     SSR    ΔSSR      R²      ΔR²        F*   p(>F)
+        ─────────────────────────────────────────────────────────────────
+        [1]    5        0.1017          0.9685                           
+        [2]    3    -2  0.1283  0.0266  0.9603  -0.0082    1.0456  0.3950
+        [3]    2    -1  3.2292  3.1008  0.0000  -0.9603  241.6234  <1e-07
+        ─────────────────────────────────────────────────────────────────"""
 
     @test_throws ArgumentError ftest(mod, bigmod, nullmod)
     @test_throws ArgumentError ftest(nullmod, bigmod, mod)


### PR DESCRIPTION
Support was dropped in https://github.com/JuliaStats/GLM.jl/pull/514