### PR TITLE
Update Documenter.yml

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,21 +1,33 @@
-name: Documentation
+name: Documenter
+
+permissions:
+  actions: write
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref }}.docs
   cancel-in-progress: true
+
 on:
   push:
-    branches:
-      - 'master'
-    tags: '*'
+    branches: [master]
+    tags: [v*]
   pull_request:
+
 jobs:
   Documenter:
+    permissions:
+      contents: write
+      statuses: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,5 +11,5 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
 DataFrames = "1"
-Documenter = "0.27"
+Documenter = "1"
 Optim = "1.6.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ makedocs(
     ],
     debug = false,
     doctest = true,
-    strict = :doctest
+    warnonly = [:missing_docs]
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,9 +11,10 @@ makedocs(
     ],
     debug = false,
     doctest = true,
-    strict = :doctest,
+    strict = :doctest
 )
 
 deploydocs(
     repo   = "github.com/JuliaStats/GLM.jl.git",
+    push_preview = true
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,35 +21,35 @@ GLM.ModResp
 ## Constructors for models
 
 The most general approach to fitting a model is with the `fit` function, as in
-```jldoctest
-julia> using Random
+```jldoctest constructors
+julia> using RDatasets
 
-julia> fit(LinearModel, hcat(ones(10), 1:10), randn(MersenneTwister(12321), 10))
+julia> df = RDatasets.dataset("mlmRev", "Oxboys");
+
+julia> fit(LinearModel, hcat(ones(nrow(df)), df.Age), df.Height)
 LinearModel
 
 Coefficients:
-────────────────────────────────────────────────────────────────
-        Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
-────────────────────────────────────────────────────────────────
-x1   0.717436    0.775175   0.93    0.3818  -1.07012    2.50499
-x2  -0.152062    0.124931  -1.22    0.2582  -0.440153   0.136029
-────────────────────────────────────────────────────────────────
+─────────────────────────────────────────────────────────────────
+        Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
+─────────────────────────────────────────────────────────────────
+x1  149.372      0.528565  282.60    <1e-99  148.33     150.413
+x2    6.52102    0.816987    7.98    <1e-13    4.91136    8.13068
+─────────────────────────────────────────────────────────────────
 ```
 
 This model can also be fit as
-```jldoctest
-julia> using Random
-
-julia> lm(hcat(ones(10), 1:10), randn(MersenneTwister(12321), 10))
+```jldoctest constructors
+julia> lm(hcat(ones(nrow(df)), df.Age), df.Height)
 LinearModel
 
 Coefficients:
-────────────────────────────────────────────────────────────────
-        Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
-────────────────────────────────────────────────────────────────
-x1   0.717436    0.775175   0.93    0.3818  -1.07012    2.50499
-x2  -0.152062    0.124931  -1.22    0.2582  -0.440153   0.136029
-────────────────────────────────────────────────────────────────
+─────────────────────────────────────────────────────────────────
+        Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
+─────────────────────────────────────────────────────────────────
+x1  149.372      0.528565  282.60    <1e-99  148.33     150.413
+x2    6.52102    0.816987    7.98    <1e-13    4.91136    8.13068
+─────────────────────────────────────────────────────────────────
 ```
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -61,13 +61,13 @@ fit
 
 ## Model methods
 ```@docs
+cooksdistance
 StatsBase.deviance
 GLM.dispersion
 GLM.ftest
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict
-StatsModels.isnested
 ```
 
 ## Links and methods applied to them

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -676,7 +676,7 @@ end
 
 const PREDICT_COMMON =
 """
-`newX` must be either a table (in the [Tables.jl]((https://tables.juliadata.org/stable/)
+`newX` must be either a table (in the [Tables.jl](https://tables.juliadata.org/stable/)
 definition) containing all columns used in the model formula, or a matrix with one column
 for each predictor in the model. In both cases, each row represents an observation for
 which a prediction will be returned.


### PR DESCRIPTION
Use specific versions of actions and enable caching.

~This will probably fail for now. Looks like there are some changes to random numbers in Julia 1.11.~ This now uses a dataset from RDatasets instead of a random dataset. This change avoids the current failure on Julia 1.11 without braking 1.10. I also think it's better to use real datasets for examples. Furthermore, the PR now fixes several warnings currently present in the docs build.