### PR TITLE
Disable previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,5 +16,6 @@ makedocs(
 
 deploydocs(
     repo   = "github.com/JuliaStats/GLM.jl.git",
-    push_preview = true
+    # Uncommented for the time being to avoid that the repo size explodes
+    # push_preview = true
 )


### PR DESCRIPTION
The current implementation seems to check in each preview causing the repo size to grow with each docs run so disabling until a different solution is available.

@palday I don't think it's a good idea to have this enabled with the current implementation. In a different context, I just noticed that the Catalyst.jl repo is ~3GB because of docs previews.