### PR TITLE
added doctest filter to match numbers upto 6 digits after decimal pt, fixes #584

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -510,7 +510,7 @@ julia> round(deviance(gm1), digits=5)
 
 In this example, we choose the best model from a set of λs, based on minimum BIC.
 
-```jldoctest
+```jldoctest; filter = r"(\d*)\.(\d{6})\d+" => s"\1.\2"
 julia> using GLM, RDatasets, StatsBase, DataFrames, Optim
 
 julia> trees = DataFrame(dataset("datasets", "trees"))


### PR DESCRIPTION
building documentation may fail because coefficients may be rounded slightly differently. this pr fixes that by adding a doctest filter for a doctest in `docs/src/example.md`

fixes #584