### PR TITLE
fixed order of return values for `inverselink(<:Link01)`

### DIFF
--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -181,7 +181,7 @@ function updateμ!(r::GlmResp{V,D,L}) where {V<:FPVector,D<:Union{Bernoulli,Bino
 
     @inbounds for i in eachindex(y, η, μ, wrkres, wrkwt, dres)
         yᵢ, ηᵢ = y[i], η[i]
-        μᵢ, omμᵢ, dμdηᵢ = inverselink(L(), ηᵢ)
+        μᵢ, dμdηᵢ, omμᵢ = inverselink(L(), ηᵢ)
         μ[i] = μᵢ
         # For large values of ηᵢ the quantities dμdη and μomμ will underflow.
         # The ratios defining (yᵢ - μᵢ)/dμdη and dμdη^2/μomμ have fairly stable

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -185,7 +185,7 @@ The variance function is returned as NaN unless the range of μ is (0, 1)
 # Examples
 ```jldoctest; setup = :(using GLM)
 julia> GLM.inverselink(LogitLink(), 0.0)
-(0.5, 0.5, 0.25)
+(0.5, 0.25, 0.5)
 
 julia> μ, oneminusμ, variance = GLM.inverselink(CloglogLink(), 0.0);
 

--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -223,7 +223,7 @@ function inverselink(::CauchitLink, η::Real)
     # atan decays so slowly that we don't need to be careful when evaluating μ
     μ = atan(η) / π
     μ += one(μ)/2
-    return μ, 1 - μ, inv(π * (1 + abs2(η)))
+    return μ, inv(π * (1 + abs2(η))), 1 - μ
 end
 
 linkfun(::CloglogLink, μ::Real) = log(-log1p(-μ))
@@ -233,7 +233,7 @@ function inverselink(::CloglogLink, η::Real)
     expη = exp(η)
     μ = -expm1(-expη)
     omμ = exp(-expη)   # the complement, 1 - μ
-    return μ, omμ, expη * omμ
+    return μ, expη * omμ, omμ
 end
 
 linkfun(::IdentityLink, μ::Real) = μ
@@ -273,7 +273,7 @@ function inverselink(::LogitLink, η::Real)
     else
         μ, omμ = 1 / opexpabs, expabs / opexpabs
     end
-    return μ, omμ, deriv
+    return μ, deriv, omμ
 end
 
 linkfun(::LogLink, μ::Real) = log(μ)
@@ -319,7 +319,7 @@ mueta(::ProbitLink, η::Real) = exp(-abs2(η) / 2) / sqrt2π
 function inverselink(::ProbitLink, η::Real)
     μ   =  cdf(Normal(), η)
     omμ = ccdf(Normal(), η)
-    return μ, omμ, pdf(Normal(), η)
+    return μ, pdf(Normal(), η), omμ
 end
 
 linkfun(::SqrtLink, μ::Real) = sqrt(μ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1011,7 +1011,7 @@ end
     gm11_pred2 = predict(gm11, newX; interval=:confidence, interval_method=:delta)
     gm11_pred3 = predict(gm11, newX; interval=:confidence, interval_method=:transformation)
     @test gm11_pred1 == gm11_pred2.prediction == gm11_pred3.prediction≈ newY
-    J = newX.*last.(GLM.inverselink.(LogitLink(), newX*coef(gm11)))
+    J = newX.*getindex.(GLM.inverselink.(LogitLink(), newX*coef(gm11)), 2)
     se_pred = sqrt.(diag(J*vcov(gm11)*J'))
     @test gm11_pred2.lower ≈ gm11_pred2.prediction .- quantile(Normal(), 0.975).*se_pred ≈
         [0.20478201781547786, 0.2894172253195125, 0.17487705636545708, 0.024943206131575357, 0.41670326978944977]


### PR DESCRIPTION
fixes #586 