### PR TITLE
Adjust tolerance when computing rank of R matrix

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1532,13 +1532,13 @@ end
     @test_throws ArgumentError glm(randn(10, 2), rand(1:10, 10), Binomial(10))
 end
 
-@testset "Issue #263" begin
+@testset "Issue #263" for method in (:cholesky, :qr)
     data = dataset("datasets", "iris")
     data.SepalWidth2 = data.SepalWidth
-    model1 = lm(@formula(SepalLength ~ SepalWidth), data)
-    model2 = lm(@formula(SepalLength ~ SepalWidth + SepalWidth2), data, true)
-    model3 = lm(@formula(SepalLength ~ 0 + SepalWidth), data)
-    model4 = lm(@formula(SepalLength ~ 0 + SepalWidth + SepalWidth2), data, true)
+    model1 = lm(@formula(SepalLength ~ SepalWidth), data; method)
+    model2 = lm(@formula(SepalLength ~ SepalWidth + SepalWidth2), data; dropcollinear = true, method)
+    model3 = lm(@formula(SepalLength ~ 0 + SepalWidth), data; method)
+    model4 = lm(@formula(SepalLength ~ 0 + SepalWidth + SepalWidth2), data; dropcollinear = true, method)
     @test dof(model1) == dof(model2)
     @test dof(model3) == dof(model4)
     @test dof_residual(model1) == dof_residual(model2)


### PR DESCRIPTION
When fitting based on a QRPivoted factorization, the tolerance used for determining the rank of R should reflect the size of the matrix of which the QR factorization was computed. Hence, a custom rtol based on that first dimension of X is passed to rank.

For consistency, all rank determinations are not handled via rank_linpred as the LinPred object has all the relevant information.

This issue was revealed by #599 