### PR TITLE
Fix .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,2 @@
-2c7923bfd596b056416c2cafc344991761550ba4
+# Initial JuliaFormatter run
+272a5b9c9cf0f4219a089913e2ebff0879b94c81


### PR DESCRIPTION
The commit listed in the `.git-blame-ignore-revs` file does not point to the commit on the master branch, and therefore is not picked up by the Github web interface (the formatting commit is not ignored by git blame): https://github.com/JuliaStats/GLM.jl/commit/2c7923bfd596b056416c2cafc344991761550ba4

The commit that should be ignored is https://github.com/JuliaStats/GLM.jl/commit/272a5b9c9cf0f4219a089913e2ebff0879b94c81

Generally, I assume it's only safe to add commits to be ignored to that file once they landed on the master branch.