### PR TITLE
[WIP] API doc for methods applied to model object

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,7 @@ fit
 ```
 
 ## Model methods
+
 ```@docs
 cooksdistance
 StatsBase.deviance
@@ -68,6 +69,9 @@ GLM.ftest
 StatsBase.nobs
 StatsBase.nulldeviance
 StatsBase.predict
+GLM.coef
+GLM.confint
+StatsBase.coeftable
 ```
 
 ## Links and methods applied to them

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -161,8 +161,6 @@ Many of the methods provided by this package have names similar to those in [R](
 - `dof`: number of degrees of freedom consumed in the model
 - `dof_residual`: degrees of freedom for residuals, when meaningful
 - `fitted`: fitted values of the model
-- `glm`: fit a generalized linear model (an alias for `fit(GeneralizedLinearModel, ...)`)
-- `lm`: fit a linear model (an alias for `fit(LinearModel, ...)`)
 - `loglikelihood`: log-likelihood of the model
 - `modelmatrix`: design matrix
 - `nobs`: number of rows, or sum of the weights when prior weights are specified

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -245,6 +245,15 @@ function GeneralizedLinearModel(rr::GlmResp, pp::LinPred,
                                   NaN, NaN)
 end
 
+
+"""
+    coeftable(mm::AbstractGLM; level::Real=0.95)
+    coeftable(mm::LinearModel; level::Real=0.95)
+
+Returns formatted table of coefficients.
+Each row shows the estimate, standard error, z statstics, p-value, lower- and upper confidence interval
+for each paramter in the model
+"""
 function coeftable(mm::AbstractGLM; level::Real=0.95)
     cc = coef(mm)
     se = stderror(mm)
@@ -259,6 +268,14 @@ function coeftable(mm::AbstractGLM; level::Real=0.95)
                      cn, 4, 3)
 end
 
+"""
+    confint(obj::AbstractGLM; level::Real=0.95)
+    confint(obj::LinearModel; level::Real=0.95)
+    
+Computes and returns the confidence interval for the coefficients as p × 2 matrix
+where p is the number of parameters in the model.
+Each row corresponds to the confidence interval for a parameter. 
+"""
 function confint(obj::AbstractGLM; level::Real=0.95)
     return hcat(coef(obj), coef(obj)) +
            stderror(obj)*quantile(Normal(), (1.0 - level)/2.0)*[1.0 -1.0]

--- a/src/glmfit.jl
+++ b/src/glmfit.jl
@@ -245,7 +245,6 @@ function GeneralizedLinearModel(rr::GlmResp, pp::LinPred,
                                   NaN, NaN)
 end
 
-
 """
     coeftable(mm::AbstractGLM; level::Real=0.95)
     coeftable(mm::LinearModel; level::Real=0.95)

--- a/src/linpred.jl
+++ b/src/linpred.jl
@@ -328,6 +328,13 @@ function nobs(obj::LinPredModel)
 end
 
 coef(x::LinPred) = x.beta0
+
+"""
+    coef(obj::LinearModel)
+    coef(obj::GLM)
+
+Returns the coefficient estimates as a vector
+"""
 coef(obj::LinPredModel) = coef(obj.pp)
 function coefnames(x::LinPredModel)
     return x.formula === nothing ? ["x$i" for i in 1:length(coef(x))] :


### PR DESCRIPTION
#607 pointed out that the API doc is missing for quite a few methods. This PR adds them.

Also removes `lm` and `glm` from the list of methods applied to fit objects in `docs/index.md`

Tracker

- [ ] adjr2: adjusted R² for a linear model (an alias for adjr²)
- [ ] aic: Akaike's Information Criterion
- [ ] aicc: corrected Akaike's Information Criterion for small sample sizes
- [ ] bic: Bayesian Information Criterion
- [x] coef: estimates of the coefficients in the model
- [x] confint: confidence intervals for coefficients
- [x] coeftable
- [x] cooksdistance: Cook's distance for each observation
- [ ] deviance: measure of the model fit, weighted residual sum of squares for lm's
- [ ] dispersion: dispersion (or scale) parameter for a model's distribution
- [ ] dof: number of degrees of freedom consumed in the model
- [ ] dof_residual: degrees of freedom for residuals, when meaningful
- [ ] fitted: fitted values of the model
- [ ] loglikelihood: log-likelihood of the model
- [ ] modelmatrix: design matrix
- [x] nobs: number of rows, or sum of the weights when prior weights are specified
- [ ] nulldeviance: deviance of the model with all predictors removed
- [ ] nullloglikelihood: log-likelihood of the model with all predictors removed
- [ ] predict: predicted values of the dependent variable from the fitted model
- [ ] r2: R² of a linear model (an alias for r²)
- [ ] residuals: vector of residuals from the fitted model
- [ ] response: model response (a.k.a the dependent variable)
- [ ] stderror: standard errors of the coefficients
- [ ] vcov: variance-covariance matrix of the coefficient estimates

fixes #607