### PR TITLE
Cleanup `fit` method arguments

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -90,19 +90,19 @@ abstract type DensePred <: LinPred end            # linear predictor with dense 
 abstract type LinPredModel <: RegressionModel end # model based on a linear predictor
 
 const COMMON_FIT_KWARGS_DOCS = """
-    - `dropcollinear::Bool`: Controls whether or not a model matrix
+    - `dropcollinear::Bool=false`: Controls whether or not a model matrix
       less-than-full rank is accepted.
       If `true` (the default) the coefficient for redundant linearly dependent columns is
       `0.0` and all associated statistics are set to `NaN`.
       Typically from a set of linearly-dependent columns the last ones are identified as redundant
       (however, the exact selection of columns identified as redundant is not guaranteed).
-    - `method::Symbol`: Controls which decomposition method to use.
+    - `method::Symbol=:qr`: Controls which decomposition method to use.
       If `method=:qr` (the default), then the `QR` decomposition method will be used.
       If `method=:cholesky`, then the `Cholesky` decomposition method will be used.
       The Cholesky decomposition is faster and more computationally efficient than
       QR, but is less numerically stable and thus may fail or produce less accurate
       estimates for some models.
-    - `wts::AbstractWeights`: Weights of observations.
+    - `wts::AbstractWeights=uweights(0)`: Weights of observations.
        The weights can be of type `AnalyticWeights`, `FrequencyWeights`,
        `ProbabilityWeights`, or `UnitWeights`. `AnalyticWeights` describe a non-random
        relative importance (usually between 0 and 1) for each observation. These weights may
@@ -111,7 +111,7 @@ const COMMON_FIT_KWARGS_DOCS = """
        `ProbabilityWeights` represent the inverse of the sampling probability for each observation,
        providing a correction mechanism for under- or over-sampling certain population groups. `UnitWeights`
        (default) describes the case in which all weights are equal to 1 (so no weighting takes place)
-    - `contrasts::AbstractDict{Symbol}`: a `Dict` mapping term names
+    - `contrasts::AbstractDict{Symbol}=Dict{Symbol,Any}()`: a `Dict` mapping term names
       (as `Symbol`s) to term types (e.g., `ContinuousTerm`) or contrasts
       (e.g., `HelmertCoding()`, `SeqDiffCoding(; levels=["a", "b", "c"])`,
       etc.). If contrasts are not provided for a variable, the appropriate

--- a/src/lm.jl
+++ b/src/lm.jl
@@ -148,19 +148,13 @@ const FIT_LM_DOC = """
     """
 
 """
-    fit(LinearModel, formula::FormulaTerm, data;
-        wts::AbstractWeights=uweights(0),
-        dropcollinear::Bool=true, method::Symbol=:qr,
-        contrasts::AbstractDict{Symbol}=Dict{Symbol,Any}())
-    fit(LinearModel, X::AbstractMatrix, y::AbstractVector;
-        wts::AbstractWeights=uweights(length(y)),
-        dropcollinear::Bool=true, method::Symbol=:qr)
+    fit(LinearModel, formula::FormulaTerm, data; <keyword arguments>)
+    fit(LinearModel, X::AbstractMatrix, y::AbstractVector; <keyword arguments>)
 
 Fit a linear model to data.
 
 $FIT_LM_DOC
 """
-
 function fit(::Type{LinearModel}, X::AbstractMatrix{<:Real}, y::AbstractVector{<:Real};
              wts::AbstractVector{<:Real}=uweights(length(y)),
              dropcollinear::Bool=true, method::Symbol=:qr)
@@ -191,19 +185,28 @@ function fit(::Type{LinearModel}, f::FormulaTerm, data;
 end
 
 """
-    lm(formula, data;
-       wts::AbstractVector{<:Real}=uweights(0), dropcollinear::Bool=true,
-       method::Symbol=:qr, contrasts::AbstractDict{Symbol}=Dict{Symbol,Any}())
-    lm(X::AbstractMatrix, y::AbstractVector;
-       wts::AbstractVector{<:Real}=uweights(length(y)), dropcollinear::Bool=true,
-       method::Symbol=:qr)
+    lm(formula::FormulaTerm, data; <keyword arguments>)
+    lm(X::AbstractMatrix, y::AbstractVector; <keyword arguments>)
 
 Fit a linear model to data.
-An alias for `fit(LinearModel, X, y; wts=wts, dropcollinear=dropcollinear, method=method)`
+An alias for `fit(LinearModel, ...)`.
 
 $FIT_LM_DOC
 """
-lm(X, y; kwargs...) = fit(LinearModel, X, y; kwargs...)
+function lm(X::AbstractMatrix, y::AbstractVector;
+            wts::Union{AbstractWeights,AbstractVector{<:Real}}=uweights(length(y)),
+            dropcollinear::Bool=true,
+            method::Symbol=:qr)
+    return fit(LinearModel, X, y; wts, dropcollinear, method)
+end
+
+function lm(f::FormulaTerm, data;
+            wts::Union{AbstractWeights,AbstractVector{<:Real}}=uweights(0),
+            dropcollinear::Bool=true,
+            method::Symbol=:qr,
+            contrasts::AbstractDict{Symbol}=Dict{Symbol,Any}())
+    return fit(LinearModel, f, data; wts, dropcollinear, method, contrasts)
+end
 
 dof(x::LinearModel) = linpred_rank(x.pp) + 1
 

--- a/test/probability_weights.jl
+++ b/test/probability_weights.jl
@@ -221,9 +221,9 @@ end
     @test stderror(model) ≈ stderror(model_geom) rtol = 1e-06
 end
 
-@testset "GLM: NegaiveBinomial(2) with SqrtLink link - ProbabilityWeights with $dmethod method with dropcollinear=$drop" for (dmethod,
-                                                                                                                              drop) in
-                                                                                                                             itr
+@testset "GLM: NegativeBinomial(2) with SqrtLink link - ProbabilityWeights with $dmethod method with dropcollinear=$drop" for (dmethod,
+                                                                                                                               drop) in
+                                                                                                                              itr
 
     model = glm(@formula(Days ~ Eth + Sex + Age + Lrn),
                 quine,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -871,6 +871,23 @@ end
             end
         end
     end
+    @testset "negbin with contrasts" begin
+        gm20b = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine, LogLink(),
+                       contrasts=Dict(:Sex => EffectsCoding()))
+        test_show(gm20b)
+        @test dof(gm20b) == 8
+        @test isapprox(deviance(gm20b), 167.9518430624193, rtol=1e-7)
+        @test isapprox(nulldeviance(gm20b), 195.28668602703388, rtol=1e-7)
+        @test isapprox(loglikelihood(gm20b), -546.57550938017, rtol=1e-7)
+        @test isapprox(nullloglikelihood(gm20b), -560.2429308624774, rtol=1e-7)
+        @test isapprox(aic(gm20b), 1109.15101876034)
+        @test isapprox(aicc(gm20b), 1110.202113650851)
+        @test isapprox(bic(gm20b), 1133.0198717340068)
+        @test isapprox(coef(gm20b)[1:7],
+                       [2.9357217632468595, -0.5693411448715979,
+                        0.041194065435350515, -0.4484636623590206,
+                        0.08805060372902418, 0.3569553124412582, 0.2921383118842893])
+    end
 end
 
 @testset "Weighted NegativeBinomial LogLink, θ to be estimated with Cholesky" begin
@@ -880,17 +897,17 @@ end
                    wts=fweights(wts))
     test_show(gm20a)
     @test dof(gm20a) == 8
-    @test isapprox(deviance(gm20a), 164.45910399188858, rtol=1e-7)
-    @test isapprox(nulldeviance(gm20a), 191.14269166948384, rtol=1e-7)
-    @test isapprox(loglikelihood(gm20a), -546.596822900127, rtol=1e-7)
-    @test isapprox(nullloglikelihood(gm20a), -559.9386167389254, rtol=1e-7)
-    @test isapprox(aic(gm20a), 1109.193645800254)
-    @test isapprox(aicc(gm20a), 1110.244740690765)
-    @test isapprox(bic(gm20a), 1133.0624987739207)
+    @test isapprox(deviance(gm20a), 168.40402933035944, rtol=1e-7)
+    @test isapprox(nulldeviance(gm20a), 196.50242701899307, rtol=1e-7)
+    @test isapprox(loglikelihood(gm20a), -537.7760823254398, rtol=1e-7)
+    @test isapprox(nullloglikelihood(gm20a), -551.8252811697569, rtol=1e-7)
+    @test isapprox(aic(gm20a), 1091.5521646508796)
+    @test isapprox(aicc(gm20a), 1092.6032595413906)
+    @test isapprox(bic(gm20a), 1115.4210176245463)
     @test isapprox(coef(gm20a)[1:7],
-                   [2.894916710026395, -0.5694300339439156,
-                    0.08215779733345588, -0.44861865904551734,
-                    0.08783288494046998, 0.3568327292046044, 0.29190920267019166])
+                   [2.9531960459074083, -0.5991180517700114,
+                    0.09609289230162256, -0.48822247493829657,
+                    0.010246721844156351, 0.362004855234784, 0.24470519461989926])
 end
 
 @testset "NegativeBinomial LogLink, θ to be estimated with QR" begin


### PR DESCRIPTION
List all arguments for all fit methods (`lm`, `glm`, `fit(LinearModel, ...)` and `fit(GeneralizedLinearModel, ...)` so that users get more friendly errors about the function they called when they make mistakes. This matters especially given the large number of arguments which makes an error likely. This requires some refactoring, notably using `nothing` as a default value instead of vector in the matrix method to match the formula method.

Also improve docs: describe keyword arguments in all docstrings instead of referring to `fit`, avoid repeating them in signature.

In the process I found a bug where weights were ignored by `negbin`. New tested values match R up to three decimals (this is tested more thoroughly via `glm` tests).