### PR TITLE
Adjust show method for fitted models

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,30 +26,34 @@ julia> using RDatasets
 
 julia> df = RDatasets.dataset("mlmRev", "Oxboys");
 
-julia> fit(LinearModel, hcat(ones(nrow(df)), df.Age), df.Height)
+julia> fit(LinearModel, @formula(Height ~ Age), df)
 LinearModel
 
+Formula: Height ~ 1 + Age
+
 Coefficients:
-─────────────────────────────────────────────────────────────────
-        Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
-─────────────────────────────────────────────────────────────────
-x1  149.372      0.528565  282.60    <1e-99  148.33     150.413
-x2    6.52102    0.816987    7.98    <1e-13    4.91136    8.13068
-─────────────────────────────────────────────────────────────────
+(Intercept)    Age
+      149.4  6.521
+
+Number of observations:                     234
+Residual degrees of freedom:                232
+Residual deviance:                      15148.5
 ```
 
 This model can also be fit as
 ```jldoctest constructors
-julia> lm(hcat(ones(nrow(df)), df.Age), df.Height)
+julia> lm(@formula(Height ~ Age), df)
 LinearModel
 
+Formula: Height ~ 1 + Age
+
 Coefficients:
-─────────────────────────────────────────────────────────────────
-        Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
-─────────────────────────────────────────────────────────────────
-x1  149.372      0.528565  282.60    <1e-99  148.33     150.413
-x2    6.52102    0.816987    7.98    <1e-13    4.91136    8.13068
-─────────────────────────────────────────────────────────────────
+(Intercept)    Age
+      149.4  6.521
+
+Number of observations:                     234
+Residual degrees of freedom:                232
+Residual deviance:                      15148.5
 ```
 
 ```@docs

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -22,9 +22,17 @@ julia> data = DataFrame(X=[1,2,3], Y=[2,4,7])
 julia> ols = lm(@formula(Y ~ X), data)
 LinearModel
 
-Y ~ 1 + X
+Formula: Y ~ 1 + X
 
 Coefficients:
+(Intercept)    X
+    -0.6667  2.5
+
+Number of observations:                       3
+Residual degrees of freedom:                  1
+Residual deviance:                     0.166667
+
+julia> coeftable(ols)
 ─────────────────────────────────────────────────────────────────────────
                  Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
 ─────────────────────────────────────────────────────────────────────────
@@ -94,9 +102,17 @@ julia> data = DataFrame(X=[1,2,3], Y=[2,4,7]);
 julia> ols = lm(@formula(Y ~ X), data; method=:qr)
 LinearModel
 
-Y ~ 1 + X
+Formula: Y ~ 1 + X
 
 Coefficients:
+(Intercept)    X
+    -0.6667  2.5
+
+Number of observations:                       3
+Residual degrees of freedom:                  1
+Residual deviance:                     0.166667
+
+julia> coeftable(ols)
 ─────────────────────────────────────────────────────────────────────────
                  Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
 ─────────────────────────────────────────────────────────────────────────
@@ -133,24 +149,26 @@ julia> y = [4.362866166172215,
 julia> modelqr = lm(X, y; method=:qr)
 LinearModel
 
+
 Coefficients:
-────────────────────────────────────────────────────────────────
-       Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
-────────────────────────────────────────────────────────────────
-x1   5.00389   0.0560164   89.33    <1e-12    4.87472    5.13307
-x2  10.0025    0.035284   283.48    <1e-16    9.92109   10.0838
-────────────────────────────────────────────────────────────────
+   x1  x2
+5.004  10
+
+Number of observations:                      10
+Residual degrees of freedom:                  8
+Residual deviance:                   9.9597e-17
 
 julia> modelchol = lm(X, y; method=:cholesky)
 LinearModel
 
+
 Coefficients:
-────────────────────────────────────────────────────────────────
-       Coef.  Std. Error       t  Pr(>|t|)  Lower 95%  Upper 95%
-────────────────────────────────────────────────────────────────
-x1   5.17647   0.0849184   60.96    <1e-11    4.98065    5.37229
-x2  10.1112    0.053489   189.03    <1e-15    9.98781   10.2345
-────────────────────────────────────────────────────────────────
+   x1     x2
+5.176  10.11
+
+Number of observations:                      10
+Residual degrees of freedom:                  8
+Residual deviance:                  2.17763e-16
 
 julia> loglikelihood(modelqr) > loglikelihood(modelchol)
 true
@@ -180,33 +198,31 @@ julia> x = [4570.2001953125, 2830, 596.799987792968, 133.600006103515, 42, 390, 
 
 julia> rdchem = DataFrame(rdintens=y, sales=x);
 
-julia> mdl = lm(@formula(rdintens ~ sales + sales^2), rdchem; method=:cholesky)
+julia> ft_cholesky = lm(@formula(rdintens ~ sales + sales^2), rdchem; method=:cholesky)
 LinearModel
 
-rdintens ~ 1 + sales + :(sales ^ 2)
+Formula: rdintens ~ 1 + sales + :(sales ^ 2)
 
 Coefficients:
-───────────────────────────────────────────────────────────────────────────────────────
-                    Coef.     Std. Error       t  Pr(>|t|)      Lower 95%     Upper 95%
-───────────────────────────────────────────────────────────────────────────────────────
-(Intercept)   0.0          NaN            NaN       NaN     NaN            NaN
-sales         0.000852509    0.000156784    5.44    <1e-05    0.000532313    0.00117271
-sales ^ 2    -1.97385e-8     4.56287e-9    -4.33    0.0002   -2.90571e-8    -1.04199e-8
-───────────────────────────────────────────────────────────────────────────────────────
+(Intercept)      sales   sales ^ 2
+          0  0.0008525  -1.974e-08
 
-julia> mdl = lm(@formula(rdintens ~ sales + sales^2), rdchem; method=:qr)
+Number of observations:                      32
+Residual degrees of freedom:                 30
+Residual deviance:                      210.956
+
+julia> ft_qr = lm(@formula(rdintens ~ sales + sales^2), rdchem; method=:qr)
 LinearModel
 
-rdintens ~ 1 + sales + :(sales ^ 2)
+Formula: rdintens ~ 1 + sales + :(sales ^ 2)
 
 Coefficients:
-─────────────────────────────────────────────────────────────────────────────────
-                    Coef.   Std. Error      t  Pr(>|t|)    Lower 95%    Upper 95%
-─────────────────────────────────────────────────────────────────────────────────
-(Intercept)   2.61251      0.429442      6.08    <1e-05   1.73421     3.49082
-sales         0.000300571  0.000139295   2.16    0.0394   1.56805e-5  0.000585462
-sales ^ 2    -6.94594e-9   3.72614e-9   -1.86    0.0725  -1.45667e-8  6.7487e-10
-─────────────────────────────────────────────────────────────────────────────────
+(Intercept)      sales   sales ^ 2
+      2.613  0.0003006  -6.946e-09
+
+Number of observations:                      32
+Residual degrees of freedom:                 29
+Residual deviance:                      92.6802
 ```
 
 
@@ -224,15 +240,18 @@ julia> data = DataFrame(X=[1,2,2], Y=[1,0,1])
 julia> probit = glm(@formula(Y ~ X), data, Binomial(), ProbitLink())
 GeneralizedLinearModel
 
-Y ~ 1 + X
+Formula: Y ~ 1 + X
+
+Family: Binomial
+Link: ProbitLink
 
 Coefficients:
-────────────────────────────────────────────────────────────────────────
-                Coef.  Std. Error      z  Pr(>|z|)  Lower 95%  Upper 95%
-────────────────────────────────────────────────────────────────────────
-(Intercept)   9.63839     293.909   0.03    0.9738   -566.414    585.69
-X            -4.81919     146.957  -0.03    0.9738   -292.849    283.211
-────────────────────────────────────────────────────────────────────────
+(Intercept)       X
+      9.638  -4.819
+
+Number of observations:                       3
+Residual degrees of freedom:                  1
+Residual deviance:                      2.77259
 ```
 
 ## Negative binomial regression
@@ -265,38 +284,34 @@ julia> quine = dataset("MASS", "quine")
 julia> nbrmodel = glm(@formula(Days ~ Eth+Sex+Age+Lrn), quine, NegativeBinomial(2.0), LogLink())
 GeneralizedLinearModel
 
-Days ~ 1 + Eth + Sex + Age + Lrn
+Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+Family: NegativeBinomial
+Link: LogLink
 
 Coefficients:
-────────────────────────────────────────────────────────────────────────────
-                  Coef.  Std. Error      z  Pr(>|z|)   Lower 95%   Upper 95%
-────────────────────────────────────────────────────────────────────────────
-(Intercept)   2.88645      0.227144  12.71    <1e-36   2.44125     3.33164
-Eth: N       -0.567515     0.152449  -3.72    0.0002  -0.86631    -0.26872
-Sex: M        0.0870771    0.159025   0.55    0.5840  -0.224606    0.398761
-Age: F1      -0.445076     0.239087  -1.86    0.0627  -0.913678    0.0235251
-Age: F2       0.0927999    0.234502   0.40    0.6923  -0.366816    0.552416
-Age: F3       0.359485     0.246586   1.46    0.1449  -0.123814    0.842784
-Lrn: SL       0.296768     0.185934   1.60    0.1105  -0.0676559   0.661191
-────────────────────────────────────────────────────────────────────────────
+(Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+      2.886  -0.5675  0.08708  -0.4451   0.0928   0.3595   0.2968
+
+Number of observations:                     146
+Residual degrees of freedom:                139
+Residual deviance:                      239.111
 
 julia> nbrmodel = negbin(@formula(Days ~ Eth+Sex+Age+Lrn), quine, LogLink())
 GeneralizedLinearModel
 
-Days ~ 1 + Eth + Sex + Age + Lrn
+Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+Family: NegativeBinomial
+Link: LogLink
 
 Coefficients:
-────────────────────────────────────────────────────────────────────────────
-                  Coef.  Std. Error      z  Pr(>|z|)   Lower 95%   Upper 95%
-────────────────────────────────────────────────────────────────────────────
-(Intercept)   2.89453      0.227415  12.73    <1e-36   2.4488      3.34025
-Eth: N       -0.569341     0.152656  -3.73    0.0002  -0.868541   -0.270141
-Sex: M        0.0823881    0.159209   0.52    0.6048  -0.229655    0.394431
-Age: F1      -0.448464     0.238687  -1.88    0.0603  -0.916281    0.0193536
-Age: F2       0.0880506    0.235149   0.37    0.7081  -0.372834    0.548935
-Age: F3       0.356955     0.247228   1.44    0.1488  -0.127602    0.841513
-Lrn: SL       0.292138     0.18565    1.57    0.1156  -0.0717297   0.656006
-────────────────────────────────────────────────────────────────────────────
+(Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+      2.895  -0.5693  0.08239  -0.4485  0.08805    0.357   0.2921
+
+Number of observations:                     146
+Residual degrees of freedom:                139
+Residual deviance:                      167.952
 
 julia> println("Estimated theta = ", round(nbrmodel.rr.d.r, digits=5))
 Estimated theta = 1.27489
@@ -329,12 +344,7 @@ julia> form = dataset("datasets", "Formaldehyde")
    5 │     0.7    0.626
    6 │     0.9    0.782
 
-julia> lm1 = fit(LinearModel, @formula(OptDen ~ Carb), form)
-LinearModel
-
-OptDen ~ 1 + Carb
-
-Coefficients:
+julia> coeftable(fit(LinearModel, @formula(OptDen ~ Carb), form))
 ───────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)   Lower 95%  Upper 95%
 ───────────────────────────────────────────────────────────────────────────
@@ -378,12 +388,7 @@ julia> LifeCycleSavings = dataset("datasets", "LifeCycleSavings")
   50 │ Malaysia           4.71    47.2      0.66   242.69     5.08
                                                     35 rows omitted
 
-julia> fm2 = lm(@formula(SR ~ Pop15 + Pop75 + DPI + DDPI), LifeCycleSavings)
-LinearModel
-
-SR ~ 1 + Pop15 + Pop75 + DPI + DDPI
-
-Coefficients:
+julia> coeftable(fit(LinearModel, @formula(SR ~ Pop15 + Pop75 + DPI + DDPI), LifeCycleSavings))
 ─────────────────────────────────────────────────────────────────────────────────
                     Coef.   Std. Error      t  Pr(>|t|)    Lower 95%    Upper 95%
 ─────────────────────────────────────────────────────────────────────────────────
@@ -469,12 +474,12 @@ In Julia this becomes
 ```jldoctest
 julia> using DataFrames, CategoricalArrays, GLM
 
-julia> dobson = DataFrame(Counts    = [18.,17,15,20,10,21,25,13,13],
+julia> dobson = DataFrame(Counts    = [18.0,17,15,20,10,21,25,13,13],
                           Outcome   = categorical([1,2,3,1,2,3,1,2,3]),
                           Treatment = categorical([1,1,1,2,2,2,3,3,3]))
 9×3 DataFrame
- Row │ Counts   Outcome  Treatment 
-     │ Float64  Cat…     Cat…      
+ Row │ Counts   Outcome  Treatment
+     │ Float64  Cat…     Cat…
 ─────┼─────────────────────────────
    1 │    18.0  1        1
    2 │    17.0  2        1
@@ -489,9 +494,20 @@ julia> dobson = DataFrame(Counts    = [18.,17,15,20,10,21,25,13,13],
 julia> gm1 = glm(@formula(Counts ~ Outcome + Treatment), dobson, Poisson())
 GeneralizedLinearModel
 
-Counts ~ 1 + Outcome + Treatment
+Formula: Counts ~ 1 + Outcome + Treatment
+
+Family: Poisson
+Link: LogLink
 
 Coefficients:
+(Intercept)  Outcome: 2  Outcome: 3  Treatment: 2  Treatment: 3
+      3.031     -0.4543     -0.2513        0.0198        0.0198
+
+Number of observations:                       9
+Residual degrees of freedom:                  4
+Residual deviance:                      5.11746
+
+julia> coeftable(gm1)
 ────────────────────────────────────────────────────────────────────────────
                    Coef.  Std. Error      z  Pr(>|z|)  Lower 95%   Upper 95%
 ────────────────────────────────────────────────────────────────────────────
@@ -501,9 +517,6 @@ Outcome: 3    -0.251314     0.190476  -1.32    0.1870  -0.624641   0.122012
 Treatment: 2   0.0198026    0.199017   0.10    0.9207  -0.370264   0.409869
 Treatment: 3   0.0198026    0.199017   0.10    0.9207  -0.370264   0.409869
 ────────────────────────────────────────────────────────────────────────────
-
-julia> round(deviance(gm1), digits=5)
-5.11746
 ```
 
 Note that for Wald tests GLM.jl uses the Normal distribution (z-statistics)
@@ -561,16 +574,18 @@ julia> round(optimal_bic.minimizer, digits = 5) # Optimal λ
 julia> glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(optimal_bic.minimizer)) # Best model
 GeneralizedLinearModel
 
-Volume ~ 1 + Height + Girth
+Formula: Volume ~ 1 + Height + Girth
+
+Family: Normal
+Link: PowerLink
 
 Coefficients:
-────────────────────────────────────────────────────────────────────────────
-                  Coef.  Std. Error      z  Pr(>|z|)   Lower 95%   Upper 95%
-────────────────────────────────────────────────────────────────────────────
-(Intercept)  -1.07586    0.352543    -3.05    0.0023  -1.76684    -0.384892
-Height        0.0232172  0.00523331   4.44    <1e-05   0.0129601   0.0334743
-Girth         0.242837   0.00922556  26.32    <1e-99   0.224756    0.260919
-────────────────────────────────────────────────────────────────────────────
+(Intercept)   Height   Girth
+     -1.076  0.02322  0.2428
+
+Number of observations:                      31
+Residual degrees of freedom:                 28
+Residual deviance:                      180.804
 
 julia> round(optimal_bic.minimum, digits=5)
 156.37638

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,12 +85,20 @@ julia> rng = StableRNG(1); # Ensure example can be reproduced
 julia> data = DataFrame(y = rand(rng, 100), x = categorical(repeat([1, 2, 3, 4], 25)));
 
 
-julia> lm(@formula(y ~ x), data)
+julia> ft = lm(@formula(y ~ x), data)
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)     x: 2     x: 3      x: 4
+      0.491  0.05277  0.09554  -0.03267
+
+Number of observations:                     100
+Residual degrees of freedom:                 96
+Residual deviance:                      7.63906
+
+julia> coeftable(ft)
 ───────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)   Lower 95%  Upper 95%
 ───────────────────────────────────────────────────────────────────────────
@@ -108,12 +116,20 @@ julia> using StableRNGs
 
 julia> data = DataFrame(y = rand(StableRNG(1), 100), x = repeat([1, 2, 3, 4], 25));
 
-julia> lm(@formula(y ~ x), data, contrasts = Dict(:x => DummyCoding()))
+julia> ft = lm(@formula(y ~ x), data, contrasts = Dict(:x => DummyCoding()))
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)     x: 2     x: 3      x: 4
+      0.491  0.05277  0.09554  -0.03267
+
+Number of observations:                     100
+Residual degrees of freedom:                 96
+Residual deviance:                      7.63906
+
+julia> coeftable(ft)
 ───────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)   Lower 95%  Upper 95%
 ───────────────────────────────────────────────────────────────────────────
@@ -157,9 +173,17 @@ julia> data = DataFrame(y = rand(StableRNG(1), 100), x = randn(StableRNG(2), 100
 julia> m = lm(@formula(y ~ x), data)
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)         x
+     0.5174  -0.05002
+
+Number of observations:                     100
+Residual degrees of freedom:                 98
+Residual deviance:                      7.67239
+
+julia> coeftable(m)
 ──────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
 ──────────────────────────────────────────────────────────────────────────
@@ -170,9 +194,17 @@ x            -0.0500249   0.0307201  -1.63    0.1066  -0.110988  0.0109382
 julia> m_aweights = lm(@formula(y ~ x), data, wts=aweights(data.weights))
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)         x
+     0.5167  -0.04787
+
+Number of observations:                     100
+Residual degrees of freedom:                 98
+Residual deviance:                      17.9526
+
+julia> coeftable(m_aweights)
 ──────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
 ──────────────────────────────────────────────────────────────────────────
@@ -183,9 +215,17 @@ x            -0.0478667   0.0308395  -1.55    0.1239  -0.109067  0.0133333
 julia> m_fweights = lm(@formula(y ~ x), data, wts=fweights(data.weights))
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)         x
+     0.5167  -0.04787
+
+Number of observations:                     250
+Residual degrees of freedom:                248
+Residual deviance:                      17.9526
+
+julia> coeftable(m_fweights)
 ─────────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)   Lower 95%    Upper 95%
 ─────────────────────────────────────────────────────────────────────────────
@@ -196,16 +236,23 @@ x            -0.0478667   0.0193863  -2.47    0.0142  -0.0860494  -0.00968394
 julia> m_pweights = lm(@formula(y ~ x), data, wts=pweights(data.weights))
 LinearModel
 
-y ~ 1 + x
+Formula: y ~ 1 + x
 
 Coefficients:
+(Intercept)         x
+     0.5167  -0.04787
+
+Number of observations:                     100
+Residual degrees of freedom:                 98
+Residual deviance:                      7.18102
+
+julia> coeftable(m_pweights)
 ───────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      t  Pr(>|t|)  Lower 95%   Upper 95%
 ───────────────────────────────────────────────────────────────────────────
 (Intercept)   0.51673     0.0287193  17.99    <1e-32   0.459737  0.573722
 x            -0.0478667   0.0265532  -1.80    0.0745  -0.100561  0.00482739
 ───────────────────────────────────────────────────────────────────────────
-
 ```
 
 !!! warning

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,6 @@ using LogExpFunctions: logistic
 using Distributions: TDist
 using Downloads
 
-test_show(x) = show(IOBuffer(), x)
-
 const glm_datadir = joinpath(dirname(@__FILE__), "..", "data")
 
 ## Formaldehyde data from the R Datasets package
@@ -58,7 +56,18 @@ end
          -9.464489795918525e-05 1.831836734693908e-04]
 
     lm1 = fit(LinearModel, @formula(OptDen ~ Carb), form; method=dmethod)
-    test_show(lm1)
+    @test sprint(show, "text/plain", lm1) == """
+        LinearModel
+
+        Formula: OptDen ~ 1 + Carb
+
+        Coefficients:
+        (Intercept)    Carb
+           0.005086  0.8763
+
+        Number of observations:                       6
+        Residual degrees of freedom:                  4
+        Residual deviance:                    0.0002992"""
     @test isapprox(coef(lm1), linreg(form.Carb, form.OptDen))
     expected_resid = [-0.006714285714285714, 0.0010285714285714898, 0.0027714285714285913,
                       0.0071428571428572285, 0.007514285714285696, -0.011742857142857166]
@@ -454,7 +463,6 @@ dobson = DataFrame(; Counts=[18.0, 17, 15, 20, 10, 20, 25, 13, 12],
     gm1 = fit(GeneralizedLinearModel, @formula(Counts ~ 1 + Outcome + Treatment),
               dobson, Poisson(); method=dmethod)
     @test GLM.cancancel(gm1.rr)
-    test_show(gm1)
     @test dof(gm1) == 5
     @test isapprox(deviance(gm1), 5.12914107700115, rtol=1e-7)
     @test isapprox(nulldeviance(gm1), 10.581445863750867, rtol=1e-7)
@@ -482,7 +490,21 @@ admit.rank = categorical(admit.rank)
                   distr();
                   method=dmethod)
         @test GLM.cancancel(gm2.rr)
-        test_show(gm2)
+        @test sprint(show, "text/plain", gm2) == """
+            GeneralizedLinearModel
+
+            Formula: admit ~ 1 + gre + gpa + rank
+
+            Family: $(distr)
+            Link: LogitLink
+
+            Coefficients:
+            (Intercept)       gre    gpa  rank: 2  rank: 3  rank: 4
+                  -3.99  0.002264  0.804  -0.6754    -1.34   -1.551
+
+            Number of observations:                     400
+            Residual degrees of freedom:                394
+            Residual deviance:                      458.517"""
         @test dof(gm2) == 6
         @test deviance(gm2) ≈ 458.5174924758994
         @test nulldeviance(gm2) ≈ 499.9765175549154
@@ -500,7 +522,21 @@ end
 @testset "Bernoulli ProbitLink with $dmethod" for dmethod in (:cholesky, :qr)
     gm3 = fit(GeneralizedLinearModel, @formula(admit ~ 1 + gre + gpa + rank), admit,
               Binomial(), ProbitLink(); method=dmethod)
-    test_show(gm3)
+    @test sprint(show, "text/plain", gm3) == """
+        GeneralizedLinearModel
+
+        Formula: admit ~ 1 + gre + gpa + rank
+
+        Family: Binomial
+        Link: ProbitLink
+
+        Coefficients:
+        (Intercept)       gre     gpa  rank: 2  rank: 3  rank: 4
+             -2.387  0.001376  0.4777  -0.4154  -0.8121  -0.9359
+
+        Number of observations:                     400
+        Residual degrees of freedom:                394
+        Residual deviance:                      458.413"""
     @test !GLM.cancancel(gm3.rr)
     @test dof(gm3) == 6
     @test isapprox(deviance(gm3), 458.4131713833386)
@@ -519,7 +555,21 @@ end
     gm4 = fit(GeneralizedLinearModel, @formula(admit ~ gre + gpa + rank), admit,
               Binomial(), CauchitLink(); method=dmethod)
     @test !GLM.cancancel(gm4.rr)
-    test_show(gm4)
+    @test sprint(show, "text/plain", gm4) == """
+        GeneralizedLinearModel
+
+        Formula: admit ~ 1 + gre + gpa + rank
+
+        Family: Binomial
+        Link: CauchitLink
+
+        Coefficients:
+        (Intercept)       gre    gpa  rank: 2  rank: 3  rank: 4
+             -3.954  0.002166  0.811  -0.6086   -1.301   -1.591
+
+        Number of observations:                     400
+        Residual degrees of freedom:                394
+        Residual deviance:                       459.34"""
     @test dof(gm4) == 6
     @test isapprox(deviance(gm4), 459.3401112751141)
     @test isapprox(nulldeviance(gm4), 499.9765175549311)
@@ -534,7 +584,21 @@ end
     gm5 = fit(GeneralizedLinearModel, @formula(admit ~ gre + gpa + rank), admit,
               Binomial(), CloglogLink(); method=dmethod)
     @test !GLM.cancancel(gm5.rr)
-    test_show(gm5)
+    @test sprint(show, "text/plain", gm5) == """
+        GeneralizedLinearModel
+
+        Formula: admit ~ 1 + gre + gpa + rank
+
+        Family: Binomial
+        Link: CloglogLink
+
+        Coefficients:
+        (Intercept)      gre     gpa  rank: 2  rank: 3  rank: 4
+             -3.535  0.00172  0.6409   -0.494   -1.045    -1.24
+
+        Number of observations:                     400
+        Residual degrees of freedom:                394
+        Residual deviance:                      458.894"""
     @test dof(gm5) == 6
     @test isapprox(deviance(gm5), 458.89439629612616)
     @test isapprox(nulldeviance(gm5), 499.97651755491677)
@@ -566,7 +630,21 @@ anorexia = CSV.read(joinpath(glm_datadir, "anorexia.csv"), DataFrame)
               Normal(), IdentityLink(); method=dmethod,
               offset=Array{Float64}(anorexia.Prewt))
     @test GLM.cancancel(gm6.rr)
-    test_show(gm6)
+    @test sprint(show, "text/plain", gm6) == """
+        GeneralizedLinearModel
+
+        Formula: Postwt ~ 1 + Prewt + Treat
+
+        Family: Normal
+        Link: IdentityLink
+
+        Coefficients:
+        (Intercept)    Prewt  Treat: Cont  Treat: FT
+              49.77  -0.5655       -4.097      4.563
+
+        Number of observations:                      72
+        Residual degrees of freedom:                 68
+        Residual deviance:                      3311.26"""
     @test dof(gm6) == 5
     @test isapprox(deviance(gm6), 3311.262619919613)
     @test isapprox(nulldeviance(gm6), 4525.386111111112)
@@ -586,7 +664,21 @@ end
     gm7 = fit(GeneralizedLinearModel, @formula(Postwt ~ 1 + Prewt + Treat), anorexia,
               Normal(), LogLink(); method=dmethod, offset=anorexia.Prewt, rtol=1e-8)
     @test !GLM.cancancel(gm7.rr)
-    test_show(gm7)
+    @test sprint(show, "text/plain", gm7) == """
+        GeneralizedLinearModel
+
+        Formula: Postwt ~ 1 + Prewt + Treat
+
+        Family: Normal
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)    Prewt  Treat: Cont  Treat: FT
+              3.992  -0.9945      -0.0507    0.05149
+
+        Number of observations:                      72
+        Residual degrees of freedom:                 68
+        Residual deviance:                      3265.21"""
     @test isapprox(deviance(gm7), 3265.207242977156)
     @test isapprox(nulldeviance(gm7), 507625.1718547432)
     @test isapprox(loglikelihood(gm7), -239.48242060326643)
@@ -605,7 +697,21 @@ end
                Poisson(), LogLink(); method=dmethod, offset=log.(anorexia.Prewt), rtol=1e-8)
 
     @test GLM.cancancel(gm7p.rr)
-    test_show(gm7p)
+    @test sprint(show, "text/plain", gm7p) == """
+        GeneralizedLinearModel
+
+        Formula: :(round(Postwt)) ~ 1 + Prewt + Treat
+
+        Family: Poisson
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)      Prewt  Treat: Cont  Treat: FT
+             0.6159  -0.007005     -0.04852    0.05331
+
+        Number of observations:                      72
+        Residual degrees of freedom:                 68
+        Residual deviance:                      39.6861"""
     @test deviance(gm7p) ≈ 39.686114742427705
     @test nulldeviance(gm7p) ≈ 54.749010639715294
     @test loglikelihood(gm7p) ≈ -245.92639857546905
@@ -623,7 +729,21 @@ end
                 wts=fweights(repeat(1:4; outer=18)), rtol=1e-8)
 
     @test GLM.cancancel(gm7pw.rr)
-    test_show(gm7pw)
+    @test sprint(show, "text/plain", gm7pw) == """
+        GeneralizedLinearModel
+
+        Formula: :(round(Postwt)) ~ 1 + Prewt + Treat
+
+        Family: Poisson
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)      Prewt  Treat: Cont  Treat: FT
+             0.6038  -0.007008     -0.03839    0.08934
+
+        Number of observations:                     180
+        Residual degrees of freedom:                176
+        Residual deviance:                      90.1705"""
     @test deviance(gm7pw) ≈ 90.17048668870225
     @test nulldeviance(gm7pw) ≈ 139.63782826574652
     @test loglikelihood(gm7pw) ≈ -610.3058020030296
@@ -643,7 +763,21 @@ clotting = DataFrame(; u=log.([5, 10, 15, 20, 30, 40, 60, 80, 100]),
               method=dmethod)
     @test !GLM.cancancel(gm8.rr)
     @test isa(GLM.Link(gm8), InverseLink)
-    test_show(gm8)
+    @test sprint(show, "text/plain", gm8) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 1 + u
+
+        Family: Gamma
+        Link: InverseLink
+
+        Coefficients:
+        (Intercept)        u
+           -0.01655  0.01534
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  7
+        Residual deviance:                    0.0167297"""
     @test dof(gm8) == 3
     @test isapprox(deviance(gm8), 0.016729715178484157)
     @test isapprox(nulldeviance(gm8), 3.5128262638285594)
@@ -662,7 +796,21 @@ end
                method=dmethod)
     @test !GLM.cancancel(gm8a.rr)
     @test isa(GLM.Link(gm8a), InverseSquareLink)
-    test_show(gm8a)
+    @test sprint(show, "text/plain", gm8a) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 1 + u
+
+        Family: InverseGaussian
+        Link: InverseSquareLink
+
+        Coefficients:
+        (Intercept)          u
+          -0.001108  0.0007219
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  7
+        Residual deviance:                   0.00693113"""
     @test dof(gm8a) == 3
     @test isapprox(deviance(gm8a), 0.006931128347234519)
     @test isapprox(nulldeviance(gm8a), 0.08779963125372384)
@@ -680,7 +828,21 @@ end
     gm9 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma(), LogLink();
               method=dmethod, rtol=1e-8, atol=0.0)
     @test !GLM.cancancel(gm9.rr)
-    test_show(gm9)
+    @test sprint(show, "text/plain", gm9) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 1 + u
+
+        Family: Gamma
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)        u
+              5.503  -0.6019
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  7
+        Residual deviance:                     0.162608"""
     @test dof(gm9) == 3
     @test deviance(gm9) ≈ 0.16260829451739
     @test nulldeviance(gm9) ≈ 3.512826263828517
@@ -699,7 +861,21 @@ end
                IdentityLink();
                method=dmethod, rtol=1e-8, atol=0.0)
     @test !GLM.cancancel(gm10.rr)
-    test_show(gm10)
+    @test sprint(show, "text/plain", gm10) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 1 + u
+
+        Family: Gamma
+        Link: IdentityLink
+
+        Coefficients:
+        (Intercept)       u
+              99.25  -18.37
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  7
+        Residual deviance:                     0.608454"""
     @test dof(gm10) == 3
     @test isapprox(deviance(gm10), 0.60845414895344)
     @test isapprox(nulldeviance(gm10), 3.512826263828517)
@@ -746,7 +922,6 @@ admit_agr2.p = admit_agr2.admit ./ admit_agr2.count
 @testset "Binomial LogitLink aggregated with $dmethod" for dmethod in (:cholesky, :qr)
     gm15 = fit(GeneralizedLinearModel, @formula(p ~ rank), admit_agr2, Binomial();
                wts=fweights(admit_agr2.count))
-    test_show(gm15)
     @test dof(gm15) == 4
     @test nobs(gm15) == 400
     @test deviance(gm15) ≈ -2.4424906541753456e-15 atol = 1e-13
@@ -764,7 +939,21 @@ end
 @testset "Gamma InverseLink Weights with $dmethod" for dmethod in (:cholesky, :qr)
     gm16 = fit(GeneralizedLinearModel, @formula(lot1 ~ 1 + u), clotting, Gamma();
                wts=fweights([1.5, 2.0, 1.1, 4.5, 2.4, 3.5, 5.6, 5.4, 6.7]))
-    test_show(gm16)
+    @test sprint(show, "text/plain", gm16) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 1 + u
+
+        Family: Gamma
+        Link: InverseLink
+
+        Coefficients:
+        (Intercept)        u
+           -0.01722  0.01565
+
+        Number of observations:                      33
+        Residual degrees of freedom:                 31
+        Residual deviance:                    0.0393339"""
     @test dof(gm16) == 3
     @test nobs(gm16) == 32.7
     @test isapprox(deviance(gm16), 0.03933389380881689)
@@ -782,7 +971,21 @@ end
     gm17 = fit(GeneralizedLinearModel, @formula(Counts ~ Outcome + Treatment), dobson,
                Poisson();
                wts=fweights([1.5, 2.0, 1.1, 4.5, 2.4, 3.5, 5.6, 5.4, 6.7]))
-    test_show(gm17)
+    @test sprint(show, "text/plain", gm17) == """
+        GeneralizedLinearModel
+
+        Formula: Counts ~ 1 + Outcome + Treatment
+
+        Family: Poisson
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)  Outcome: B  Outcome: C  Treatment: b  Treatment: c
+              3.122      -0.527      -0.403      -0.01785      -0.03508
+
+        Number of observations:                      33
+        Residual degrees of freedom:                 28
+        Residual deviance:                      17.6999"""
     @test dof(gm17) == 5
     @test isapprox(deviance(gm17), 17.699857821414266)
     @test isapprox(nulldeviance(gm17), 47.37955120289139)
@@ -802,7 +1005,21 @@ quine = dataset("MASS", "quine")
     gm18 = fit(GeneralizedLinearModel, @formula(Days ~ Eth + Sex + Age + Lrn), quine,
                NegativeBinomial(2.0), LogLink(); method=dmethod)
     @test !GLM.cancancel(gm18.rr)
-    test_show(gm18)
+    @test sprint(show, "text/plain", gm18) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+              2.886  -0.5675  0.08708  -0.4451   0.0928   0.3595   0.2968
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      239.111"""
     @test dof(gm18) == 8
     @test isapprox(deviance(gm18), 239.11105911824325, rtol=1e-7)
     @test isapprox(nulldeviance(gm18), 280.1806722491237, rtol=1e-7)
@@ -822,7 +1039,21 @@ end
     gm19 = fit(GeneralizedLinearModel, @formula(Days ~ Eth + Sex + Age + Lrn),
                quine, NegativeBinomial(2.0))
     @test GLM.cancancel(gm19.rr)
-    test_show(gm19)
+    @test sprint(show, "text/plain", gm19) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: NegativeBinomialLink
+
+        Coefficients:
+        (Intercept)    Eth: N   Sex: M   Age: F1  Age: F2  Age: F3  Lrn: SL
+            -0.1274  -0.05587  0.01562  -0.04111  0.02404    0.044  0.03577
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      239.686"""
     @test dof(gm19) == 8
     @test isapprox(deviance(gm19), 239.68562048977307, rtol=1e-7)
     @test isapprox(nulldeviance(gm19), 280.18067224912204, rtol=1e-7)
@@ -839,7 +1070,21 @@ end
 
 @testset "NegativeBinomial LogLink, θ to be estimated with Cholesky" begin
     gm20 = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine, LogLink())
-    test_show(gm20)
+    @test sprint(show, "text/plain", gm20) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+              2.895  -0.5693  0.08239  -0.4485  0.08805    0.357   0.2921
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      167.952"""
     @test dof(gm20) == 8
     @test isapprox(deviance(gm20), 167.9518430624193, rtol=1e-7)
     @test isapprox(nulldeviance(gm20), 195.28668602703388, rtol=1e-7)
@@ -874,7 +1119,21 @@ end
     @testset "negbin with contrasts" begin
         gm20b = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine, LogLink(),
                        contrasts=Dict(:Sex => EffectsCoding()))
-        test_show(gm20b)
+        @test sprint(show, "text/plain", gm20b) == """
+            GeneralizedLinearModel
+
+            Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+            Family: NegativeBinomial
+            Link: LogLink
+
+            Coefficients:
+            (Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+                  2.936  -0.5693  0.04119  -0.4485  0.08805    0.357   0.2921
+
+            Number of observations:                     146
+            Residual degrees of freedom:                139
+            Residual deviance:                      167.952"""
         @test dof(gm20b) == 8
         @test isapprox(deviance(gm20b), 167.9518430624193, rtol=1e-7)
         @test isapprox(nulldeviance(gm20b), 195.28668602703388, rtol=1e-7)
@@ -895,7 +1154,21 @@ end
     wts = vcat(fill(0.8, halfn), fill(1.2, size(quine, 1) - halfn))
     gm20a = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine, LogLink();
                    wts=fweights(wts))
-    test_show(gm20a)
+    @test sprint(show, "text/plain", gm20a) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+              2.953  -0.5991  0.09609  -0.4882  0.01025    0.362   0.2447
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      168.404"""
     @test dof(gm20a) == 8
     @test isapprox(deviance(gm20a), 168.40402933035944, rtol=1e-7)
     @test isapprox(nulldeviance(gm20a), 196.50242701899307, rtol=1e-7)
@@ -912,7 +1185,21 @@ end
 
 @testset "NegativeBinomial LogLink, θ to be estimated with QR" begin
     gm20 = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine, LogLink(); method=:qr)
-    test_show(gm20)
+    @test sprint(show, "text/plain", gm20) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)   Eth: N   Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+              2.895  -0.5693  0.08239  -0.4485  0.08805    0.357   0.2921
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      167.952"""
     @test dof(gm20) == 8
     @test isapprox(deviance(gm20), 167.9518430624193, rtol=1e-7)
     @test isapprox(nulldeviance(gm20), 195.28668602703388, rtol=1e-7)
@@ -932,7 +1219,21 @@ end
                                                                                        :qr)
     # the default/canonical link is NegativeBinomialLink
     gm21 = negbin(@formula(Days ~ Eth + Sex + Age + Lrn), quine; method=dmethod)
-    test_show(gm21)
+    @test sprint(show, "text/plain", gm21) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: NegativeBinomial
+        Link: NegativeBinomialLink
+
+        Coefficients:
+        (Intercept)    Eth: N   Sex: M   Age: F1  Age: F2  Age: F3  Lrn: SL
+           -0.08289  -0.03697  0.01028  -0.02741  0.01582  0.02907  0.02363
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      168.047"""
     @test dof(gm21) == 8
     @test isapprox(deviance(gm21), 168.0465485656672, rtol=1e-7)
     @test isapprox(nulldeviance(gm21), 194.85525025005109, rtol=1e-7)
@@ -951,7 +1252,22 @@ end
     # the default/canonical link is LogLink
     gm22 = glm(@formula(Days ~ Eth + Sex + Age + Lrn), quine, Geometric();
                method=dmethod)
-    test_show(gm22)
+
+    @test sprint(show, "text/plain", gm22) == """
+        GeneralizedLinearModel
+
+        Formula: Days ~ 1 + Eth + Sex + Age + Lrn
+
+        Family: Geometric
+        Link: LogLink
+
+        Coefficients:
+        (Intercept)   Eth: N  Sex: M  Age: F1  Age: F2  Age: F3  Lrn: SL
+              2.898  -0.5701  0.0804  -0.4498  0.08623   0.3559   0.2902
+
+        Number of observations:                     146
+        Residual degrees of freedom:                139
+        Residual deviance:                      137.878"""
     @test dof(gm22) == 7
     @test deviance(gm22) ≈ 137.8781581814965
     @test loglikelihood(gm22) ≈ -548.3711276642073
@@ -997,7 +1313,21 @@ end
     @test !hasintercept(nointglm1)
     @test !GLM.cancancel(nointglm1.rr)
     @test isa(GLM.Link(nointglm1), InverseLink)
-    test_show(nointglm1)
+    @test sprint(show, "text/plain", nointglm1) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 0 + u
+
+        Family: Gamma
+        Link: InverseLink
+
+        Coefficients:
+             u
+        0.0092
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  8
+        Residual deviance:                      0.66299"""
     @test dof(nointglm1) == 2
     @test deviance(nointglm1) ≈ 0.6629903395245351
     @test isnan(nulldeviance(nointglm1))
@@ -1015,7 +1345,21 @@ end
                     Bernoulli())
     @test !hasintercept(nointglm2)
     @test GLM.cancancel(nointglm2.rr)
-    test_show(nointglm2)
+    @test sprint(show, "text/plain", nointglm2) == """
+        GeneralizedLinearModel
+
+        Formula: admit ~ 0 + gre + gpa
+
+        Family: Bernoulli
+        Link: LogitLink
+
+        Coefficients:
+             gre      gpa
+        0.001562  -0.4823
+
+        Number of observations:                     400
+        Residual degrees of freedom:                398
+        Residual deviance:                      503.558"""
     @test dof(nointglm2) == 2
     @test deviance(nointglm2) ≈ 503.5584368354113
     @test nulldeviance(nointglm2) ≈ 554.5177444479574
@@ -1034,7 +1378,21 @@ end
                     wts=fweights(repeat(1:4; outer=18)), rtol=1e-8, dropcollinear=false)
     @test !hasintercept(nointglm3)
     @test GLM.cancancel(nointglm3.rr)
-    test_show(nointglm3)
+    @test sprint(show, "text/plain", nointglm3) == """
+        GeneralizedLinearModel
+
+        Formula: :(round(Postwt)) ~ 0 + Prewt + Treat
+
+        Family: Poisson
+        Link: LogLink
+
+        Coefficients:
+            Prewt  Treat: CBT  Treat: Cont  Treat: FT
+        -0.007008      0.6038       0.5654     0.6932
+
+        Number of observations:                     180
+        Residual degrees of freedom:                176
+        Residual deviance:                      90.1705"""
     @test deviance(nointglm3) ≈ 90.17048668870225
     @test nulldeviance(nointglm3) ≈ 159.32999067102548
     @test loglikelihood(nointglm3) ≈ -610.3058020030296
@@ -1056,7 +1414,21 @@ end
     @test !hasintercept(nointglm1)
     @test !GLM.cancancel(nointglm1.rr)
     @test isa(GLM.Link(nointglm1), InverseLink)
-    test_show(nointglm1)
+    @test sprint(show, "text/plain", nointglm1) == """
+        GeneralizedLinearModel
+
+        Formula: lot1 ~ 0 + u
+
+        Family: Gamma
+        Link: InverseLink
+
+        Coefficients:
+             u
+        0.0092
+
+        Number of observations:                       9
+        Residual degrees of freedom:                  8
+        Residual deviance:                      0.66299"""
     @test dof(nointglm1) == 2
     @test deviance(nointglm1) ≈ 0.6629903395245351
     @test isnan(nulldeviance(nointglm1))
@@ -1073,7 +1445,21 @@ end
     nointglm2 = glm(@formula(admit ~ 0 + gre + gpa), admit, Bernoulli(); method=dmethod)
     @test !hasintercept(nointglm2)
     @test GLM.cancancel(nointglm2.rr)
-    test_show(nointglm2)
+    @test sprint(show, "text/plain", nointglm2) == """
+        GeneralizedLinearModel
+
+        Formula: admit ~ 0 + gre + gpa
+
+        Family: Bernoulli
+        Link: LogitLink
+
+        Coefficients:
+             gre      gpa
+        0.001562  -0.4823
+
+        Number of observations:                     400
+        Residual degrees of freedom:                398
+        Residual deviance:                      503.558"""
     @test dof(nointglm2) == 2
     @test deviance(nointglm2) ≈ 503.5584368354113
     @test nulldeviance(nointglm2) ≈ 554.5177444479574
@@ -1092,7 +1478,21 @@ end
                     wts=fweights(repeat(1:4; outer=18)), rtol=1e-8, dropcollinear=false)
     @test !hasintercept(nointglm3)
     @test GLM.cancancel(nointglm3.rr)
-    test_show(nointglm3)
+    @test sprint(show, "text/plain", nointglm3) == """
+        GeneralizedLinearModel
+
+        Formula: :(round(Postwt)) ~ 0 + Prewt + Treat
+
+        Family: Poisson
+        Link: LogLink
+
+        Coefficients:
+            Prewt  Treat: CBT  Treat: Cont  Treat: FT
+        -0.007008      0.6038       0.5654     0.6932
+
+        Number of observations:                     180
+        Residual degrees of freedom:                176
+        Residual deviance:                      90.1705"""
     @test deviance(nointglm3) ≈ 90.17048668870225
     @test nulldeviance(nointglm3) ≈ 159.32999067102548
     @test loglikelihood(nointglm3) ≈ -610.3058020030296


### PR DESCRIPTION
Only show the coefficients instead of the full coefficients table. At the time of the fitting, the user cannot pass arguments related to inference such as the level of the confidence interval, so it is better to only show this output when calling coeftable explicitly.

Also, include the distribution family and link function when fitting glms as well as include the number of observations, the residual degrees of freedom and the residual deviance in the output.

Adjust the show method to include MIME"text/plain" as it is producing "decorated" output. Finally, explicitly test the show method agaist reference output instead of just writing it to an IOBuffer.