### PR TITLE
Stop considering that Geometric has a dispersion parameter

### DIFF
--- a/src/glmtools.jl
+++ b/src/glmtools.jl
@@ -452,18 +452,20 @@ devresid(::Poisson, y, μ::Real) = 2 * (xlogy(y, y / μ) - (y - μ))
 
 Does distribution `D` have a separate dispersion parameter, ϕ?
 
-Returns `false` for the `Bernoulli`, `Binomial`, and `Poisson` distributions, `true` otherwise.
+Returns `true` for `Gamma`, `InverseGaussian`, `NegativeBinomial`
+and `Normal` distributions, and false for other known distributions.
 
 # Examples
 ```jldoctest; setup = :(using GLM)
-julia> show(GLM.dispersion_parameter(Normal()))
+julia> GLM.dispersion_parameter(Normal())
 true
-julia> show(GLM.dispersion_parameter(Bernoulli()))
+
+julia> GLM.dispersion_parameter(Bernoulli())
 false
 ```
 """
-dispersion_parameter(D) = true
-dispersion_parameter(::Union{Bernoulli,Binomial,Poisson}) = false
+dispersion_parameter(::Union{Gamma,InverseGaussian,NegativeBinomial,Normal}) = true
+dispersion_parameter(::Union{Bernoulli,Binomial,Geometric,Poisson}) = false
 
 """
     _safe_int(x::T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -952,18 +952,23 @@ end
     gm22 = glm(@formula(Days ~ Eth + Sex + Age + Lrn), quine, Geometric();
                method=dmethod)
     test_show(gm22)
-    @test dof(gm22) == 8
+    @test dof(gm22) == 7
     @test deviance(gm22) ≈ 137.8781581814965
     @test loglikelihood(gm22) ≈ -548.3711276642073
-    @test aic(gm22) ≈ 1112.7422553284146
-    @test aicc(gm22) ≈ 1113.7933502189255
-    @test bic(gm22) ≈ 1136.6111083020812
+    @test aic(gm22) ≈ 1110.742255328415
+    @test aicc(gm22) ≈ 1111.5538495313135
+    @test bic(gm22) ≈ 1131.6275016803734
     @test coef(gm22)[1:7] ≈ [2.8978546663153897, -0.5701067649409168, 0.08040181505082235,
                              -0.4497584898742737, 0.08622664933901254, 0.3558996662512287,
                              0.29016080736927813]
-    @test stderror(gm22) ≈ [0.22754287093719366, 0.15274755092180423, 0.15928431669166637,
-                            0.23853372776980591, 0.2354231414867577, 0.24750780320597515,
-                            0.18553339017028742]
+    # Values match R with
+    # summary(glm(cbind(1, Days) ~ Eth + Sex + Age + Lrn, data=quine, family=binomial))
+    # or summary(glm(..., family=negative.binomial(1)), dispersion=1)
+    # (as by default summary.glm estimates the dispersion instead of fixing
+    # it to 1 as it should)
+    @test stderror(gm22) ≈ [0.2556768565484684, 0.17163365085581442, 0.17897863915251788,
+                            0.26802665117909047, 0.2645314640101982, 0.2781103043759507,
+                            0.20847321556654236]
 end
 
 @testset "Geometric is a special case of NegativeBinomial with θ = 1 and $dmethod" for dmethod in
@@ -974,14 +979,15 @@ end
     gm24 = glm(@formula(Days ~ Eth + Sex + Age + Lrn), quine, NegativeBinomial(1),
                InverseLink(); method=dmethod)
     @test coef(gm23) ≈ coef(gm24)
-    @test stderror(gm23) ≈ stderror(gm24)
-    @test confint(gm23) ≈ confint(gm24)
-    @test dof(gm23) ≈ dof(gm24)
+    # This is broken as dispersion_parameter(::NegativeBinomial) should be false (#624)
+    @test_broken stderror(gm23) ≈ stderror(gm24)
+    @test_broken confint(gm23) ≈ confint(gm24)
+    @test_broken dof(gm23) ≈ dof(gm24)
     @test deviance(gm23) ≈ deviance(gm24)
     @test loglikelihood(gm23) ≈ loglikelihood(gm24)
-    @test aic(gm23) ≈ aic(gm24)
-    @test aicc(gm23) ≈ aicc(gm24)
-    @test bic(gm23) ≈ bic(gm24)
+    @test_broken aic(gm23) ≈ aic(gm24)
+    @test_broken aicc(gm23) ≈ aicc(gm24)
+    @test_broken bic(gm23) ≈ bic(gm24)
     @test predict(gm23) ≈ predict(gm24)
 end
 


### PR DESCRIPTION
This is just incorrect. Fix tests to reflect correct degrees of freedom and therefore AIC, BIC and standard errors.

Also avoid defining `dispersion_parameter` fallback for any distribution: it's clearer for users to get a `MethodError` so that they have to define the appropriate method themselves, than silently returning a wrong value.

`NegativeBinomial` will be fixed separately as it requires a deeper refactoring of `negbin` (#624).

Fixes #564, and part of #617.